### PR TITLE
Fix deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,18 +4,21 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
-require 'rubocop'
-require 'rubocop/rake_task'
-
 Rails.application.load_tasks
 
-if defined? RuboCop
-  desc "Run style checker"
-  RuboCop::RakeTask.new(:rubocop) do |task|
-    task.requires << "rubocop-rspec"
-    task.fail_on_error = true
-  end
+if Rails.env.development? || Rails.env.test?
 
-  desc "Run test suite and style checker"
-  task spec: :rubocop
+  require 'rubocop'
+  require 'rubocop/rake_task'
+
+  if defined? RuboCop
+    desc "Run style checker"
+    RuboCop::RakeTask.new(:rubocop) do |task|
+      task.requires << "rubocop-rspec"
+      task.fail_on_error = true
+    end
+
+    desc "Run test suite and style checker"
+    task spec: :rubocop
+  end
 end


### PR DESCRIPTION
Capistrano deploy was failing because it couldn't find rubocop. 
This PR fixes the problem by not requiring rubocop unless running in development or test mode (i.e. not on a server)