### PR TITLE
Plausible fix (oops)

### DIFF
--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -21,7 +21,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-file-earmark-arrow-down-fill">
                       <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1zm-1 4v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 11.293V7.5a.5.5 0 0 1 1 0z"></path>
                     </svg>
-                    <a href="#" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
+                    <a href="#" class="documents-file-link" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
                   </span>
                 </td>
                 <td>
@@ -41,3 +41,13 @@
     </div>
   </div>
 </section>
+
+<script type="text/javascript">
+$(function() {
+  $(".documents-file-link").click(function() {
+    var filename = $(this).text();
+    log_plausible(filename);
+    return true;
+  });
+});
+</script>


### PR DESCRIPTION
Updated the Plausible call to track each individual file rather than pushing to plausible the entire list of files for the document.

I noticed this issue because I accidentally overwrote @kelynch [original code for tracking downloads via Plausible](https://github.com/pulibrary/pdc_discovery/commit/30e85a31f82ae0aa5a9926b986256d0a10ea9f25#) when I resolved conflicts in my previous PR. 

The original code was pushing to Plausible the entire list of files for the document rather than tracking individual files as the new implementation does. 

