### PR TITLE
Indexes (and displays) bitstream metadata

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,10 +81,11 @@ class SolrDocument
     fetch(METHODS_FIELD, [])
   end
 
-  def documents
-    file1 = { file_name: { href: '', content: 'file1.csv' }, file_size: '10KB' }
-    file2 = { file_name: { href: '', content: 'File2.xml' }, file_size: '15kb' }
-    [file1, file2]
+  def files
+    files ||= begin
+      data = JSON.parse(fetch("files_ss", "[]"))
+      data.sort_by { |file| (file["sequence"] || "").to_i }
+    end
   end
 
   def referenced_by

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,12 +81,14 @@ class SolrDocument
     fetch(METHODS_FIELD, [])
   end
 
+  # rubocop:disable Lint/UselessAssignment
   def files
     files ||= begin
       data = JSON.parse(fetch("files_ss", "[]"))
       data.sort_by { |file| (file["sequence"] || "").to_i }
     end
   end
+  # rubocop:enable Lint/UselessAssignment
 
   def referenced_by
     fetch("referenced_by_ssim", [])

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -11,7 +11,7 @@
             </tr>
           </thead>
           <tbody>
-            <% @document.documents.each_with_index do |document, ix| %>
+            <% @document.files.each_with_index do |file, ix| %>
               <tr class="document-download">
                 <th scope="row">
                   <span><span><%= ix + 1 %></span></span>
@@ -21,11 +21,11 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-file-earmark-arrow-down-fill">
                       <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1zm-1 4v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 11.293V7.5a.5.5 0 0 1 1 0z"></path>
                     </svg>
-                    <a href=""><%= document[:file_name][:content]%></a>
+                    <a href="#" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
                   </span>
                 </td>
                 <td>
-                  <span><span><%= document[:file_size]%></span></span>
+                  <span><span><%= number_to_human_size(file["size"]) %></span></span>
                 </td>
               </tr>
             <% end %>

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -113,3 +113,18 @@ to_field 'local_id_ssim', extract_xpath("/item/metadata/key[text()='dc.identifie
 # (e.g. doi:10.1088/0029-5515/57/1/016034 in document id: 84912)?
 # Should we fix them before we index them?
 to_field 'referenced_by_ssim', extract_xpath("/item/metadata/key[text()='dc.relation.isreferencedby']/../value")
+
+# ==================
+# Store all files metadata as a single JSON string so that we can display detailed information for each of them.
+to_field 'files_ss' do |record, accumulator, _context|
+  bitstreams = record.xpath("/item/bitstreams").map do |node|
+    {
+      name: node.xpath("name").text,
+      format: node.xpath("format").text,
+      size: node.xpath("sizeBytes").text,
+      mime_type: node.xpath("mimeType").text,
+      sequence: node.xpath("sequenceId").text
+    }
+  end
+  accumulator.concat [bitstreams.to_json.to_s]
+end

--- a/spec/system/research_data_indexing_spec.rb
+++ b/spec/system/research_data_indexing_spec.rb
@@ -33,4 +33,9 @@ describe 'DataSpace research data indexing', type: :system do
   it 'referenced_by' do
     expect(result['referenced_by_ssim'].first).to eq 'https://arxiv.org/abs/1903.06605'
   end
+
+  it 'files' do
+    files = JSON.parse(result['files_ss'].first)
+    expect(files.first["name"]).to eq 'Lee_princeton_0181D_10086.pdf'
+  end
 end


### PR DESCRIPTION
Indexes bitstreams metadata from dspace into Solr and displays it on the show page

![files](https://user-images.githubusercontent.com/568286/142498994-6a329820-98b4-4b1c-a294-6bc19dbde774.png)

It does not handle pagination of many files yet, but the data is now real.

Notice that I am **storing but not indexing** all the files' metadata as a single JSON string in Solr. We parse that JSON string in Rails so that we can display the individual pieces of information for each file. At one point we probably want to index some of this metadata too (e.g. the filenames) so that users can find datasets by filename, but that is not done on this PR.
