### PR TITLE
Makes Bootstrap icons available

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -36,7 +36,7 @@
         <div class="document-abstract">
           <header>Abstract:</header>
           <p id="document-abstract-text" class="truncate-line-clamp"><%= abstract %></p>
-            <a id="document-abstract-text-toggle" href="#" class="document-abstract--collapse__button">Show More</a>
+            <a id="document-abstract-text-toggle" href="#"><i class="bi bi-caret-down"></i><span>Show More</span></a>
         </div>
       </dd>
     <% end %>
@@ -47,7 +47,7 @@
         <div class="document-description">
           <header>Description:</header>
           <p id="document-description-text" class="truncate-line-clamp"><%= description %></p>
-            <a id="document-description-text-toggle" href="#" class="document-description--collapse__button">Show More</a>
+            <a id="document-description-text-toggle" href="#"><i class="bi bi-caret-down"></i><span>Show More</span></a>
         </div>
       </dd>
     <% end %>
@@ -70,10 +70,12 @@ $(function() {
     $(linkId).click(function() {
       if ($(linkId).text() == "Show Less") {
         $(textId).addClass("truncate-line-clamp");
-        $(linkId).text("Show More");
+        $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
+        $(linkId + " span").text("Show More");
       } else {
         $(textId).removeClass("truncate-line-clamp");
-        $(linkId).text("Show Less");
+        $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
+        $(linkId + " span").text("Show Less");
       }
       return false;
     });

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -11,6 +11,7 @@
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= javascript_include_tag "application" %>
     <%= stylesheet_pack_tag "application" %>


### PR DESCRIPTION
Reference Bootstrap icons and use them for the show more/less buttons in the Show page. 

With this change we can now reference any icon in listed here https://icons.getbootstrap.com/ by adding the proper class name, e.g.:

```
<i class="bi bi-chevron-double-up"></i>
```

Screenshots below.

![show_more](https://user-images.githubusercontent.com/568286/144321417-3294232d-e310-43f5-a3b0-6d7ba02c965e.png)

![show_less](https://user-images.githubusercontent.com/568286/144321448-1a9d0d85-b02c-465e-84b3-469d42adc701.png)

