### PR TITLE
Index and display the file (bitstream) description.

### DIFF
--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -7,6 +7,7 @@
             <tr>
               <th scope="col" nowrap="nowrap"><span>#</span></th>
               <th scope="col" nowrap="nowrap"><span>Filename</span></th>
+              <th scope="col"><span>Description</span></th>
               <th scope="col" nowrap="nowrap"><span>Filesize</span></th>
             </tr>
           </thead>
@@ -18,11 +19,11 @@
                 </th>
                 <td>
                   <span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-file-earmark-arrow-down-fill">
-                      <path d="M9.293 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V4.707A1 1 0 0 0 13.707 4L10 .293A1 1 0 0 0 9.293 0zM9.5 3.5v-2l3 3h-2a1 1 0 0 1-1-1zm-1 4v3.793l1.146-1.147a.5.5 0 0 1 .708.708l-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 0 1 .708-.708L7.5 11.293V7.5a.5.5 0 0 1 1 0z"></path>
-                    </svg>
-                    <a href="#" class="documents-file-link" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
+                    <i class="bi bi-file-arrow-down-fill"></i> <a href="#" class="documents-file-link" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
                   </span>
+                </td>
+                <td>
+                  <span><%= file["description"] %></span>
                 </td>
                 <td>
                   <span><span><%= number_to_human_size(file["size"]) %></span></span>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -11,6 +11,7 @@
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, opensearch_catalog_url(format: 'xml') %>
     <%= favicon_link_tag %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= javascript_include_tag "application" %>
     <%= stylesheet_pack_tag "application" %>

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -300,6 +300,7 @@ to_field 'files_ss' do |record, accumulator, _context|
   bitstreams = record.xpath("/item/bitstreams").map do |node|
     {
       name: node.xpath("name").text,
+      description: node.xpath("description").text,
       format: node.xpath("format").text,
       size: node.xpath("sizeBytes").text,
       mime_type: node.xpath("mimeType").text,


### PR DESCRIPTION
During the demo by Neggin and Matt I notice they mentioned that files sometimes have a **description** so I went ahead and indexed that field and display in the Show page.

![with_data](https://user-images.githubusercontent.com/568286/144324230-50dc5bd4-1214-45ae-bc55-489ec4e4560f.png)

I am not sure how often this data will be populated, a lot of datasets that I tested had no data so it looks a bit weird

![empty](https://user-images.githubusercontent.com/568286/144324291-01fef888-52df-48ff-882c-3801ffea395c.png)

...and I also ran into a few records where the "reame" file has the description of "extracted text"

![extracted_text](https://user-images.githubusercontent.com/568286/144324361-ce1fd8b1-332a-408d-bb53-0a62e0afa365.png)


