### PR TITLE
Added support to download files

### DIFF
--- a/app/models/dataset_file.rb
+++ b/app/models/dataset_file.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class DatasetFile
+  attr_accessor :name, :description, :format, :size, :mime_type, :sequence, :handle
+
+  def self.from_hash(data)
+    hash = data.with_indifferent_access
+    file = DatasetFile.new
+    file.name = hash[:name]
+    file.description = hash[:description]
+    file.mime_type = hash[:mime_type]
+    file.size = hash[:size]
+    file.mime_type = hash[:mime_type]
+    file.sequence = (hash[:sequence] || "").to_i
+    # Technically the handle is a property of the dataset item rather than the file (aka bitstream)
+    # but we store it at the file level for convenience.
+    file.handle = hash[:handle]
+    file
+  end
+
+  def self.download_root
+    "https://dataspace-dev.princeton.edu/bitstream"
+  end
+
+  def download_url
+    # We use the handle URL from DataSpace (instead of the bitstream/retrieveLink property in DataSpace)
+    # when downloading the file because the handle URL provides the proper HTTP headers (e.g. name, mime type)
+    # that allows the browser to interpret the file correctly.
+    "#{DatasetFile.download_root}/#{handle}/#{sequence}/#{name}"
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -90,7 +90,7 @@ class SolrDocument
   def files
     files ||= begin
       data = JSON.parse(fetch("files_ss", "[]"))
-      data.sort_by { |file| (file["sequence"] || "").to_i }
+      data.map { |x| DatasetFile.from_hash(x) }.sort_by(&:sequence)
     end
   end
   # rubocop:enable Lint/UselessAssignment

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -19,14 +19,15 @@
                 </th>
                 <td>
                   <span>
-                    <i class="bi bi-file-arrow-down-fill"></i> <a href="#" class="documents-file-link" title="<%= file['name'] %>"><%= truncate(file["name"], length: 60) %></a>
+                    <i class="bi bi-file-arrow-down-fill"></i>
+                    <a href="<%= file.download_url %>" class="documents-file-link" target="_blank" title="<%= file.name %>"><%= truncate(file.name, length: 60) %></a>
                   </span>
                 </td>
                 <td>
-                  <span><%= file["description"] %></span>
+                  <span><%= file.description %></span>
                 </td>
                 <td>
-                  <span><span><%= number_to_human_size(file["size"]) %></span></span>
+                  <span><span><%= number_to_human_size(file.size) %></span></span>
                 </td>
               </tr>
             <% end %>

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -38,6 +38,9 @@ to_field 'title_ssim', extract_xpath("/item/metadata/key[text()='dcterms.title']
 to_field 'title_tsim', extract_xpath("/item/metadata/key[text()='dcterms.title']/../value")
 to_field 'uri_tesim', extract_xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
 
+to_field 'collection_id_ssi', extract_xpath('/item/parentCollection/id')
+to_field 'handle_ssi', extract_xpath('/item/handle')
+
 # Calculate domain from the communities
 to_field 'domain_ssi' do |record, accumulator, _context|
   communities = record.xpath("/item/parentCommunityList/type[text()='community']/../name").map(&:text)
@@ -297,6 +300,7 @@ to_field 'source_ssim', extract_xpath("/item/metadata/key[text()='dcterms.source
 # ==================
 # Store all files metadata as a single JSON string so that we can display detailed information for each of them.
 to_field 'files_ss' do |record, accumulator, _context|
+  dataspace_handle = record.xpath('/item/handle/text()').text
   bitstreams = record.xpath("/item/bitstreams").map do |node|
     {
       name: node.xpath("name").text,
@@ -304,7 +308,8 @@ to_field 'files_ss' do |record, accumulator, _context|
       format: node.xpath("format").text,
       size: node.xpath("sizeBytes").text,
       mime_type: node.xpath("mimeType").text,
-      sequence: node.xpath("sequenceId").text
+      sequence: node.xpath("sequenceId").text,
+      handle: dataspace_handle
     }
   end
   accumulator.concat [bitstreams.to_json.to_s]

--- a/spec/models/dataset_file_spec.rb
+++ b/spec/models/dataset_file_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatasetFile do
+  describe "#download_url" do
+    it "builds the proper URL" do
+      hash = { name: "big file.zip", handle: "123/dsp456", sequence: 1 }
+      file = described_class.from_hash(hash)
+      expect(file.download_url).to eq "https://dataspace-dev.princeton.edu/bitstream/123/dsp456/1/big file.zip"
+    end
+  end
+end


### PR DESCRIPTION
Indexed a few extra fields to allow us to build the proper URL to download each file from DataSpace.

Big thanks to @jrgriffiniii for helping me figure out the correct DataSpace URL for the download. This will force authentication plus provides the right file name and MIME type for the browser to download the file with sensible defaults.

![download](https://user-images.githubusercontent.com/568286/144489871-b1539657-2204-4140-8c5b-a92c3e3a83ef.png)

Fixes #33 
