### PR TITLE
Subject facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -90,6 +90,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'domain_ssi', label: 'Domain'
     config.add_facet_field 'author_ssim', label: 'Author'
     config.add_facet_field 'genre_ssim', label: 'Genre'
+    config.add_facet_field 'subject_all_ssim', label: 'Subject'
     config.add_facet_field 'publisher_ssim', label: 'Publisher'
     config.add_facet_field 'year_available_itsi', label: 'Year Available', range: true
 

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -119,28 +119,28 @@
               <%= render_field_row "License", license %>
             <% end %>
             <% @document.subject.each do |subject| %>
-              <%= render_field_row_link "Subject", subject %>
+              <%= render_field_row_search_link "Subject", subject, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_classification.each do |subject_classification| %>
-              <%= render_field_row_link "Classification", subject_classification %>
+              <%= render_field_row_search_link "Classification", subject_classification, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_ddc.each do |subject_ddc| %>
-              <%= render_field_row_link "Dewey Decimal Classification", subject_ddc %>
+              <%= render_field_row_search_link "Dewey Decimal Classification", subject_ddc, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_lcc.each do |subject_lcc| %>
-              <%= render_field_row_link "Library of Congress Classification", subject_lcc %>
+              <%= render_field_row_search_link "Library of Congress Classification", subject_lcc, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_lcsh.each do |subject_lcsh| %>
-              <%= render_field_row_link "Library of Congress Subject Headings", subject_lcsh %>
+              <%= render_field_row_search_link "Library of Congress Subject Headings", subject_lcsh, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_mesh.each do |subject_mesh| %>
-              <%= render_field_row_link "Medical Subject Headings", subject_mesh %>
+              <%= render_field_row_search_link "Medical Subject Headings", subject_mesh, "subject_all_ssim" %>
             <% end %>
             <% @document.subject_other.each do |subject_other| %>
-              <%= render_field_row_link "Subject", subject_other %>
+              <%= render_field_row_search_link "Subject", subject_other, "subject_all_ssim" %>
             <% end %>
             <% @document.genre.each do |genre| %>
-              <%= render_field_row_link "Genre", genre %>
+              <%= render_field_row_search_link "Genre", genre, "genre_ssim" %>
             <% end %>
             <% @document.peer_review_status.each do |peer_review_status| %>
               <%= render_field_row "Peer Review Status", peer_review_status %>

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -263,6 +263,16 @@ to_field 'subject_lcsh_tesim', extract_xpath("/item/metadata/key[text()='dc.subj
 to_field 'subject_mesh_tesim', extract_xpath("/item/metadata/key[text()='dc.subject.mesh']/../value")
 to_field 'subject_other_tesim', extract_xpath("/item/metadata/key[text()='dc.subject.other']/../value")
 
+# subject_all_ssim is used for faceting (must be string)
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dcterms.subject']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.classification']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.ddc']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.lcc']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.lcsh']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.mesh']/../value")
+to_field 'subject_all_ssim', extract_xpath("/item/metadata/key[text()='dc.subject.other']/../value")
+
 # ==================
 # genre, provenance, peer review, alternative title fields
 to_field 'genre_ssim', extract_xpath("/item/metadata/key[text()='dc.type']/../value")


### PR DESCRIPTION
Indexed all the subjects into a single `subject_all_ssim` field and use this new field as a facet for Subjects. The Show page has also been updated to have links that execute a search that filters by this new field.

Notice that the combination of all subjects into a single subject field might not be a good idea since they represent multiple vocabularies, but it might also be an overkill to have 10 "subject" facets in the search page, so I took a gamble and bundle them all for now in the Search page.

# Search Page
![subject_search](https://user-images.githubusercontent.com/568286/144504021-a4145821-49f3-4594-a28f-afdae8f56b4a.png)

# Show Page
![subject_show](https://user-images.githubusercontent.com/568286/144504357-56ed52f6-cbae-42e6-aea8-6fe42aa44496.png)

Related to #73 


