### PR TITLE
Issue 67 version

### DIFF
--- a/app/assets/stylesheets/modules/deployment_version.scss
+++ b/app/assets/stylesheets/modules/deployment_version.scss
@@ -9,6 +9,8 @@
   margin-left: $space-base;
   margin-right: $space-base;
 
+  color: #aaa; /* gray */
+
   .lux-text-style[data-v-ba32f400] {
     font-size: $font-size-x-small;
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,7 @@
 <div class="lux">
   <div class="deployment-version" >
-    <text-style variation="strong">Version<span title="<%= GIT_SHA %>"><%= BRANCH %> last updated <%= LAST_DEPLOYED %></span>
+    <text-style variation="strong">
+      Version: <span title="<%= GIT_SHA %>"><%= BRANCH %>, last updated: <%= LAST_DEPLOYED %></span>
     </text-style>
   </div>
   <library-footer></library-footer>

--- a/config/initializers/git_sha.rb
+++ b/config/initializers/git_sha.rb
@@ -3,8 +3,8 @@
 revisions_logfile = Rails.root.join("..", "..", "revisions.log")
 
 GIT_SHA =
-  if File.exist?(revisions_logfile)
-    `tail -1 #{revisions_logfile}`.chomp.split(" ")[3].gsub(/\)$/, '')
+  if File.exists?("REVISION")
+    File.read("REVISION").chomp.gsub(/\)$/, '')
   elsif Rails.env.development? || Rails.env.test?
     `git rev-parse HEAD`.chomp
   else
@@ -13,7 +13,13 @@ GIT_SHA =
 
 BRANCH =
   if File.exist?(revisions_logfile)
-    `tail -1 #{revisions_logfile}`.chomp.split(" ")[1]
+    revisions_line = `tail -1 #{revisions_logfile}`.chomp
+    revisions_sha = revisions_line.split(" ")[3]
+    if revisions_sha != GIT_SHA
+      "(stale)"
+    else
+      revisions_line.split(" ")[1]
+    end
   elsif Rails.env.development? || Rails.env.test?
     `git rev-parse --abbrev-ref HEAD`.chomp
   else
@@ -22,8 +28,12 @@ BRANCH =
 
 LAST_DEPLOYED =
   if File.exist?(revisions_logfile)
-    deployed = `tail -1 #{revisions_logfile}`.chomp.split(" ")[7]
-    Date.parse(deployed).strftime("%d %B %Y")
+    deployed_dir = Dir.getwd.split("/").last
+    if deployed_dir.start_with?(/\d\d\d\d\d\d\d\d/)
+      Date.parse(deployed_dir).strftime("%d %B %Y")
+    else
+      "N/A"
+    end
   else
     "Not in deployed environment"
   end


### PR DESCRIPTION
Attempt at addressing the issue with the stale version information displayed on the footer

It seems that the culprit is that Capistrano does not update the `revisions.log` file until after the application has been restarted (see sequence of events here: https://capistranorb.com/documentation/getting-started/flow/). 

This "fix" uses the `GIT_SHA` from the local `REVISION` file and the `date` from the current folder and should always give up to date information. The downside is that the `BRANCH` information is not available anywhere else but the problematic `revisions.log` and I am still attempting to get it from that file, I added a check to see if the information in `revisions.log` is stale and indicate so if that is the case, an ugly workaround to say the least.

Fixes #67

See also PR #112 