### PR TITLE
Configurable Dataspace URL

### DIFF
--- a/app/lib/indexer.rb
+++ b/app/lib/indexer.rb
@@ -39,7 +39,7 @@ class Indexer
   # Convenience method for kicking off indexing
   # @example Indexer.index(collection_handle: '88435/dsp015m60qr913')
   def self.index(_options)
-    server = 'https://dataspace-dev.princeton.edu/rest'
+    server = "#{Rails.configuration.pdc_discovery.dataspace_url}/rest"
     collection_id = '261'
     url = "#{server}/collections/#{collection_id}/items?limit=#{REST_LIMIT}&offset=0&expand=all"
 

--- a/app/lib/research_data_harvester.rb
+++ b/app/lib/research_data_harvester.rb
@@ -18,7 +18,7 @@ class ResearchDataHarvester
   end
 
   def server
-    'https://dataspace-dev.princeton.edu/rest'
+    "#{Rails.configuration.pdc_discovery.dataspace_url}/rest"
   end
 
   ##

--- a/app/models/dataset_file.rb
+++ b/app/models/dataset_file.rb
@@ -19,7 +19,7 @@ class DatasetFile
   end
 
   def self.download_root
-    "https://dataspace-dev.princeton.edu/bitstream"
+    "#{Rails.configuration.pdc_discovery.dataspace_url}/bitstream"
   end
 
   def download_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,7 @@ module PdcDiscovery
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.pdc_discovery = config_for(:pdc_discovery)
   end
 end

--- a/config/pdc_discovery.yml
+++ b/config/pdc_discovery.yml
@@ -1,0 +1,15 @@
+default: &default
+  dataspace_url: <%= ENV["DATASPACE_URL"] || "https://dataspace-dev.princeton.edu" %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default
+  dataspace_url: <%= ENV["DATASPACE_URL"] %>
+
+staging:
+  <<: *default


### PR DESCRIPTION
Replaces hard-coded URL for Dataspace with config value defined in `pdc_discovery.yml`

Fixes #49 
