### PR TITLE
Index tuning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :test do
   gem 'capybara', '>= 3.26'
   gem 'coveralls', require: false
+  gem 'rspec-solr'
   gem 'selenium-webdriver'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,9 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rspec'
   gem 'rspec-rails', '~> 5.0.0'
+  gem 'rspec-solr'
   gem 'rubocop-rspec'
 end
 
@@ -58,7 +60,6 @@ end
 group :test do
   gem 'capybara', '>= 3.26'
   gem 'coveralls', require: false
-  gem 'rspec-solr'
   gem 'selenium-webdriver'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
   rsolr (>= 1.0, < 3)
+  rspec
   rspec-rails (~> 5.0.0)
   rspec-solr
   rubocop-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,6 +318,12 @@ GEM
     rsolr (2.3.0)
       builder (>= 2.1.2)
       faraday (>= 0.9.0)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-collection_matchers (1.2.0)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -334,6 +340,9 @@ GEM
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
+    rspec-solr (3.0.0)
+      rspec (~> 3.5)
+      rspec-collection_matchers
     rspec-support (3.10.2)
     rubocop (0.85.1)
       parallel (~> 1.10)
@@ -492,6 +501,7 @@ DEPENDENCIES
   rails (~> 6.1.4)
   rsolr (>= 1.0, < 3)
   rspec-rails (~> 5.0.0)
+  rspec-solr
   rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -324,3 +324,9 @@ to_field 'files_ss' do |record, accumulator, _context|
   end
   accumulator.concat [bitstreams.to_json.to_s]
 end
+
+# Indexes the entire text in a catch-all field.
+to_field 'all_text_timv' do |record, accumulator, _context|
+  all_text = record.xpath("//text()").map { |x| x.to_s }.join(" ")
+  accumulator.concat [all_text]
+end

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -327,6 +327,6 @@ end
 
 # Indexes the entire text in a catch-all field.
 to_field 'all_text_timv' do |record, accumulator, _context|
-  all_text = record.xpath("//text()").map { |x| x.to_s }.join(" ")
+  all_text = record.xpath("//text()").map(&:to_s).join(" ")
   accumulator.concat [all_text]
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -193,9 +193,8 @@
     <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
-    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
+    <!-- We populate this field manually via Traject (rather than via copyFields) -->
     <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-
 
   </fields>
 
@@ -204,11 +203,6 @@
       Another way to map multiple source fields to the same
       destination field is to use the dynamic field syntax.
       copyField also supports a maxChars to copy setting.  -->
-
-  <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_ssim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_si" dest="all_text_timv" maxChars="3000"/>
 
   <copyField source="*_tsim" dest="suggest"/>
   <copyField source="*_tesim" dest="suggest"/>

--- a/spec/system/default_search_spec.rb
+++ b/spec/system/default_search_spec.rb
@@ -10,7 +10,7 @@ describe "Default search", type: :system do
       indexer.index
     end
 
-    it "finds value only indexed in catch all field" do
+    it "finds value only indexed in catch all field." do
       num_docs = solr_num_documents({ q: 'Stotler_PoP.zip' })
       expect(num_docs).to be 1
 

--- a/spec/system/default_search_spec.rb
+++ b/spec/system/default_search_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe "Default search", type: :system do
+  context "indexing all text" do
+    before do
+      solr_delete_all!
+      xml = file_fixture("../single_item.xml").read
+      indexer = Indexer.new(xml)
+      indexer.index
+    end
+
+    it "finds value only indexed in catch all field" do
+      num_docs = solr_num_documents({ q: 'Stotler_PoP.zip' })
+      expect(num_docs).to be 1
+
+      num_docs = solr_num_documents({ q: 'not-existing-file.txt' })
+      expect(num_docs).to be 0
+    end
+  end
+end


### PR DESCRIPTION
Updates the indexing process to index the entire text of a DSpace item into the `all_text_timv` and changed the Solr configuration to not pre-populate this field via copyField directives.

Added a small test to validate that a value in the DSpace XML that is not indexed in a specific Solr field is still found via the `all_text_timv` field. Field `all_text_timv` is automatically used in a default search because that's how our Solr core is configured (see https://github.com/pulibrary/pdc_discovery/blob/main/solr/conf/solrconfig.xml#L53)

Below are a couple of screenshots showing how a search for a value that we don't index as an specific Solr field still is found because the value is indexed in the catch all `all_text_timv` field.

## Search Page
![search_page](https://user-images.githubusercontent.com/568286/145484030-2fe26e48-b276-4c1b-9009-fa84ac5c8b7e.png)

## Show Page
![show_page](https://user-images.githubusercontent.com/568286/145484055-8bec4d38-b3a2-479d-98d7-1641eb1998ae.png)

