### PR TITLE
Handles exceptions when fetching recently added feeds 

### DIFF
--- a/spec/models/recently_added.rb
+++ b/spec/models/recently_added.rb
@@ -4,27 +4,38 @@ require 'rails_helper'
 
 RSpec.describe RecentlyAdded do
   let(:recently_added) { file_fixture("recent.json") }
-  before do
-    stub_request(:get, "http://pdc-discovery-test/catalog.json").to_return(
-      status: 200,
-      body: recently_added,
-      headers: {
-        'Content-Type' => 'application/json;charset=UTF-8',
-        'Accept' => 'application/json',
-        'User-Agent' => 'Faraday v1.0.1'
-      }
-    )
+  context "with a valid URL" do
+    before do
+      stub_request(:get, "http://pdc-discovery-test/catalog.json").to_return(
+        status: 200,
+        body: recently_added,
+        headers: {
+          'Content-Type' => 'application/json;charset=UTF-8',
+          'Accept' => 'application/json',
+          'User-Agent' => 'Faraday v1.0.1'
+        }
+      )
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it "returns a payload of ten most recent items with required fields" do
+      resp = described_class.feed("http://pdc-discovery-test")
+      expect(resp.count).to eq 10
+      expect(resp.first[1][:title]).to eq "Nonlinear fishbone dynamics in spherical tokamaks"
+      expect(resp.first[1][:link]).to eq "http://localhost:3000/catalog/84912"
+      expect(resp.first[1][:author]).to eq "Wang, F., Fu, G.Y., and Shen, W."
+      expect(resp.first[1][:genre]).to eq "Dataset"
+      expect(resp.first[1][:issue_date]).to eq "January 2017"
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 
-  # rubocop:disable RSpec/ExampleLength
-  it "returns a payload of ten most recent items with required fields" do
-    resp = described_class.feed("http://pdc-discovery-test")
-    expect(resp.count).to eq 10
-    expect(resp.first[1][:title]).to eq "Nonlinear fishbone dynamics in spherical tokamaks"
-    expect(resp.first[1][:link]).to eq "http://localhost:3000/catalog/84912"
-    expect(resp.first[1][:author]).to eq "Wang, F., Fu, G.Y., and Shen, W."
-    expect(resp.first[1][:genre]).to eq "Dataset"
-    expect(resp.first[1][:issue_date]).to eq "January 2017"
+  context "with an invalid URL" do
+    # This test is important because the recently added feeds can be unavailable
+    # immeditaly after a release.
+    it "handles HTTP exceptions" do
+      resp = described_class.feed("xttp://pdc-discovery-test")
+      expect(resp).to be {}
+    end
   end
-  # rubocop:enable RSpec/ExampleLength
 end


### PR DESCRIPTION
Handles exceptions when fetching recently added feeds (and uses a short timeout value to prevent the home page from hanging if the request takes a while to come back.)

This is to address the issue that @Bess noticed today after deploying to production (https://app.honeybadger.io/projects/95072/faults/82987347)

