### PR TITLE
Restyle the display of the Keywords in the Show page.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,7 +50,7 @@ module ApplicationHelper
   # Outputs the HTML to render a list of subjects
   # rubocop:disable Rails/OutputSafety
   def render_subject_search_links(title, values, field)
-    return if values.count == 0
+    return if values.count.zero?
     links_html = values.map do |value|
       "<span>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark', style: 'font-size: 12pt; font-weight: normal;')}</span>"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,24 @@ module ApplicationHelper
   end
   # rubocop:enable Rails/OutputSafety
 
+  # Outputs the HTML to render a list of subjects
+  # rubocop:disable Rails/OutputSafety
+  def render_subject_search_links(title, values, field)
+    return if values.count == 0
+    links_html = values.map do |value|
+      "<span>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark', style: 'font-size: 12pt; font-weight: normal;')}</span>"
+    end
+
+    html = <<-HTML
+    <tr>
+      <th scope="row"><span>#{title}</span></th>
+      <td>#{links_html.join(' ')}</td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+  # rubocop:enable Rails/OutputSafety
+
   # rubocop:disable Rails/OutputSafety
   def render_globus_download(uri)
     return if uri.blank?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,13 +52,13 @@ module ApplicationHelper
   def render_subject_search_links(title, values, field)
     return if values.count.zero?
     links_html = values.map do |value|
-      "<span>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark', style: 'font-size: 12pt; font-weight: normal;')}</span>"
+      "<span>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark')}</span>"
     end
 
     html = <<-HTML
     <tr>
-      <th scope="row"><span>#{title}</span></th>
-      <td>#{links_html.join(' ')}</td>
+      <th scope="row" style="vertical-align: top;"><span>#{title}: </span></th>
+      <td style="vertical-align: top;">#{links_html.join(' ')}</td>
     </tr>
     HTML
     html.html_safe

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -118,9 +118,7 @@
             <% @document.license.each do |license| %>
               <%= render_field_row "License", license %>
             <% end %>
-            <% @document.subject.each do |subject| %>
-              <%= render_field_row_search_link "Subject", subject, "subject_all_ssim" %>
-            <% end %>
+            <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
             <% @document.subject_classification.each do |subject_classification| %>
               <%= render_field_row_search_link "Classification", subject_classification, "subject_all_ssim" %>
             <% end %>

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -115,10 +115,6 @@
             <% @document.access_rights.each do |access_rights| %>
               <%= render_field_row "Access Rights", access_rights %>
             <% end %>
-            <% @document.license.each do |license| %>
-              <%= render_field_row "License", license %>
-            <% end %>
-            <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
             <% @document.subject_classification.each do |subject_classification| %>
               <%= render_field_row_search_link "Classification", subject_classification, "subject_all_ssim" %>
             <% end %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -3,3 +3,12 @@
     <li><span class="number"><%= Rails.env.production? ? views : 'X' %> </span> <i class="bi bi-eye-fill"></i>views</li>
   </ul>
 </div>
+
+<div id="sidebar-keywords" class="sidebar">
+  <table>
+    <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
+      <% @document.license.each do |license| %>
+      <%= render_field_row "License: ", license %>
+    <% end %>
+  </table>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -8,6 +8,11 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
+
+  .sidebar {
+    border: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0.25rem;
+  }
 </style>
 <% @page_title = "#{@document.title} || 'untitled'" %>
 <% content_for(:head) { render_link_rel_alternates } %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -8,11 +8,6 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-
-  .sidebar {
-    border: 1px solid rgba(0, 0, 0, 0.125);
-    border-radius: 0.25rem;
-  }
 </style>
 <% @page_title = "#{@document.title} || 'untitled'" %>
 <% content_for(:head) { render_link_rel_alternates } %>


### PR DESCRIPTION
Display the Keywords (subjects) on the Show page in a sidebar as badges that work as links that search on the specific keyword (you cannot tell in the screenshot that they are links, but it's apparent on the browser.)

Fixes #40 

I left the other subject fields (Classification, Dewey Decimal Classification, Library of Congress Classification, Library of Congress Subject Headings, Medical Subject Headings, Subject, and Genre) un-touched.

I did move the License display to the sidebar as suggested on the wire frame (although I have not made this as hyperlink, that would be a separate issue)

![Screen Shot 2022-01-27 at 3 58 37 PM](https://user-images.githubusercontent.com/568286/151442638-64085f67-a6c0-4d3c-be8f-ab813872dac7.png)


