### PR TITLE
Round borders for sidebar 

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -1,7 +1,8 @@
-#sidebar-usage {
+.sidebar {
   float: right;
   margin: 10px;
   border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
   width: 25%;
   ul {
     padding: 0;


### PR DESCRIPTION
Fixes issue in which the Keywords sidebar was displaying without a border. 

## Before
![Screen Shot 2022-01-28 at 11 13 26 AM](https://user-images.githubusercontent.com/568286/151582135-fc06bf30-f68e-4517-835e-6209940abfbf.png)

## After
![Screen Shot 2022-01-28 at 11 22 15 AM](https://user-images.githubusercontent.com/568286/151583521-e0fa5a0c-b9f8-4497-9b95-048b620ca145.png)


