### PR TITLE
Fixes display of very long keywords in the sidebar

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -32,3 +32,11 @@
 .sidebar-value {
   vertical-align: top;
 }
+
+.sidebar-value-badge {
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,13 +55,13 @@ module ApplicationHelper
     return if values.count.zero?
     # Must use <divs> instead of <spans> for them to wrap inside the sidebar
     links_html = values.map do |value|
-      "<div>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark')}</div>"
+      "#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields", class: 'badge badge-dark sidebar-value-badge', title: value)}<br/>"
     end
 
     html = <<-HTML
     <tr>
       <th scope="row" class="sidebar-label"><span>#{title}: </span></th>
-      <td class="sidebar-value">#{links_html.join(' ')}</td>
+      <td>#{links_html.join(' ')}</td>
     </tr>
     HTML
     html.html_safe


### PR DESCRIPTION
Truncates keywords that are too long and displays an ellipsis at the end. The full text is available as a tooltip if the user mouses over the keyword.

![Screen Shot 2022-01-31 at 11 25 05 AM](https://user-images.githubusercontent.com/568286/151832571-5bbbdf5d-65ab-4d9f-993b-d5677f7830ec.png)
