### PR TITLE
Show more/less fields in the metadata section of the Show page.

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -2,3 +2,12 @@
   float: left;
   width: 70%;
 }
+
+/*
+ * This class is different from Bootstrap's visible (https://getbootstrap.com/docs/4.1/utilities/visibility/)
+ * since `hidden-row` changes the page layout. This is what we want in the Show page as we render each of
+ * the metadata elements in an HTML table rows.
+ */
+.hidden-row {
+  display: none;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,56 +1,92 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/OutputSafety
 module ApplicationHelper
-  def render_document_heading; end
-
   # Outputs the HTML to render a single value as an HTML table row
-  # rubocop:disable Rails/OutputSafety
-  def render_field_row(title, value, sidebar = false)
+  # to be displayed on the metadata section of the show page.
+  def render_field_row(title, value, show_always = false)
     return if value.nil?
-    return if value.empty? && render_empty == false
-    value_encoded = html_escape(value)
-    css_label = sidebar ? "sidebar-label" : ""
-    css_value = sidebar ? "sidebar-value" : ""
+    css_class = show_always ? "" : "toggable-row hidden-row"
     html = <<-HTML
-    <tr>
-      <th scope="row" class="#{css_label}"><span>#{title}</span></th>
-      <td class="#{css_value}"><span>#{value_encoded}</span></td>
+    <tr class="#{css_class}">
+      <th scope="row"><span>#{title}</span></th>
+      <td><span>#{html_escape(value)}</span></td>
     </tr>
     HTML
     html.html_safe
   end
-  # rubocop:enable Rails/OutputSafety
+
+  # Outputs the HTML to render multiple values as an HTML table row
+  def render_field_row_many(title, values, show_always = false)
+    return if values.blank?
+    values_encoded = values.map { |v| html_escape(v) }
+    css_class = show_always ? "" : "toggable-row hidden-row"
+    html = <<-HTML
+    <tr class="#{css_class}">
+      <th scope="row"><span>#{title.pluralize(values.count)}</span></th>
+      <td><span>#{values_encoded.join(', ')}</span></td>
+    </tr>
+    HTML
+    html.html_safe
+  end
 
   # Outputs the HTML to render a single value as an HTML table row with a link
-  # rubocop:disable Rails/OutputSafety
-  def render_field_row_link(title, url)
+  def render_field_row_link(title, url, show_always = false)
     return if url.blank?
+    css_class = show_always ? "" : "toggable-row hidden-row"
     html = <<-HTML
-    <tr>
+    <tr class="#{css_class}">
       <th scope="row"><span>#{title}</span></th>
       <td><span>#{link_to(url, url, target: '_blank', rel: 'noopener noreferrer')}</span></td>
     </tr>
     HTML
     html.html_safe
   end
-  # rubocop:enable Rails/OutputSafety
 
   # Outputs the HTML to render a single value as an HTML table row with a search link
-  # rubocop:disable Rails/OutputSafety
-  def render_field_row_search_link(title, value, field)
+  def render_field_row_search_link(title, value, field, show_always = false)
     return if value.blank?
+    css_class = show_always ? "" : "toggable-row hidden-row"
     html = <<-HTML
-    <tr>
+    <tr class="#{css_class}">
       <th scope="row"><span>#{title}</span></th>
       <td><span>#{link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields")}</span></td>
     </tr>
     HTML
     html.html_safe
   end
-  # rubocop:enable Rails/OutputSafety
+
+  # Outputs the HTML to render a single value as an HTML table row with a search link
+  def render_field_row_search_links(title, values, field, show_always = false)
+    return if values.blank?
+    css_class = show_always ? "" : "toggable-row hidden-row"
+    links = values.map do |value|
+      "<span>" + link_to(value, "/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields") + "</span>"
+    end
+    html = <<-HTML
+    <tr class="#{css_class}">
+      <th scope="row"><span>#{title.pluralize(values.count)}</span></th>
+      <td>#{links.join(', ')}</td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
+  # Outputs the HTML to render a single value as an HTML table row
+  # to be displayed on the sidebar.
+  def render_sidebar_row(title, value)
+    return if value.nil?
+    html = <<-HTML
+    <tr>
+      <th scope="row" class="sidebar-label"><span>#{title}</span></th>
+      <td class="sidebar-value"><span>#{html_escape(value)}</span></td>
+    </tr>
+    HTML
+    html.html_safe
+  end
 
   # Outputs the HTML to render a list of subjects
-  # rubocop:disable Rails/OutputSafety
+  # (this is used on the sidebar)
   def render_subject_search_links(title, values, field)
     return if values.count.zero?
     # Must use <divs> instead of <spans> for them to wrap inside the sidebar
@@ -66,21 +102,18 @@ module ApplicationHelper
     HTML
     html.html_safe
   end
-  # rubocop:enable Rails/OutputSafety
 
-  # rubocop:disable Rails/OutputSafety
   def render_globus_download(uri)
     return if uri.blank?
     html = <<-HTML
     <div id="globus">
-      <button data-v-b7851b04="" type="button" class="document-downloads__button lux-button solid medium">#{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer')}
-        <svg data-v-b7851b04="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-cloud-arrow-down-fill">
-          <path data-v-b7851b04="" d="M8 2a5.53 5.53 0 0 0-3.594 1.342c-.766.66-1.321 1.52-1.464 2.383C1.266 6.095 0 7.555 0 9.318 0 11.366 1.708 13 3.781 13h8.906C14.502 13 16 11.57 16 9.773c0-1.636-1.242-2.969-2.834-3.194C12.923 3.999 10.69 2 8 2zm2.354 6.854-2 2a.5.5 0 0 1-.708 0l-2-2a.5.5 0 1 1 .708-.708L7.5 9.293V5.5a.5.5 0 0 1 1 0v3.793l1.146-1.147a.5.5 0 0 1 .708.708z"></path>
-        </svg>
+      <button data-v-b7851b04="" type="button" class="document-downloads__button lux-button solid medium">
+        #{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer')}
+        <i class="bi bi-cloud-arrow-down-fill"></i>
       </button>
     </div>
     HTML
     html.html_safe
   end
-  # rubocop:enable Rails/OutputSafety
 end
+# rubocop:enable Rails/OutputSafety

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -85,6 +85,14 @@ class SolrDocument
     fetch("contributor_tsim", [])
   end
 
+  def accessioned_dates
+    fetch("date_accessioned_ssim", [])
+  end
+
+  def accessioned_date
+    accessioned_dates.first
+  end
+
   def issued_dates
     fetch(ISSUED_DATE_FIELD, [])
   end

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -6,25 +6,21 @@
         <table class="table">
           <thead></thead>
           <tbody>
-            <% @document.alternative_title.each do |alternative_title| %>
-              <%= render_field_row "Alternative Title", alternative_title %>
-            <% end %>
-            <% @document.authors.each do |author| %>
-              <%= render_field_row "Author", author %>
-            <% end %>
-            <% @document.creators.each do |creator| %>
-              <%= render_field_row "Creator", creator %>
-            <% end %>
-            <% @document.contributors.each do |contributor| %>
-              <%= render_field_row "Contributor", contributor %>
-            <% end %>
+            <%= render_field_row_many "Alternative Title", @document.alternative_title %>
+            <%= render_field_row_many "Author", @document.authors, true %> <!-- here -->
+            <%= render_field_row_many "Creator", @document.creators %>
+            <%= render_field_row_many "Contributor", @document.contributors %>
             <%= render_field_row_search_link "Domain", @document.domain, "domain_ssi" %>
-            <%= render_field_row "Issued Date", @document.issued_date %>
+            <%= render_field_row "Date Accessioned", @document.accessioned_date, true %> <!-- here -->
+            <%= render_field_row "Date Issued", @document.issued_date, true %> <!-- here -->
             <%= render_field_row "Date Created", @document.date_created %>
             <%= render_field_row "Date Modified", @document.date_modified %>
             <%= render_field_row "Date Submitted", @document.date_submitted %>
             <%= render_field_row "Date Accepted", @document.date_accepted %>
             <%= render_field_row "Date Copyrighted", @document.date_copyrighted %>
+            <% @document.uri.each do |uri| %>
+              <%= render_field_row_link "URI", uri, true %> <!-- here -->
+            <% end %>
             <% @document.dates_valid.each do |date_valid| %>
               <%= render_field_row "Date Valid", date_valid %>
             <% end %>
@@ -46,9 +42,7 @@
             <% @document.mimetype.each do |mimetype| %>
               <%= render_field_row "Mimetype", mimetype %>
             <% end %>
-            <% @document.language.each do |language| %>
-              <%= render_field_row "Language", language %>
-            <% end %>
+            <%= render_field_row_many "Language", @document.language %>
             <% @document.publisher.each do |publisher| %>
               <%= render_field_row "Publisher", publisher %>
             <% end %>
@@ -133,9 +127,7 @@
             <% @document.subject_other.each do |subject_other| %>
               <%= render_field_row_search_link "Subject", subject_other, "subject_all_ssim" %>
             <% end %>
-            <% @document.genres.each do |genre| %>
-              <%= render_field_row_search_link "Genre", genre, "genre_ssim" %>
-            <% end %>
+            <%= render_field_row_search_links "Genre", @document.genres, "genre_ssim" %>
             <% @document.peer_review_status.each do |peer_review_status| %>
               <%= render_field_row "Peer Review Status", peer_review_status %>
             <% end %>
@@ -198,14 +190,10 @@
             <% end %>
           </tbody>
           <tfoot>
-            <tr>
-              <th scope="row">
-                <!-- TODO: Move this to a helper -->
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16" class="bi bi-caret-down">
-                  <path d="M3.204 5h9.592L8 10.481 3.204 5zm-.753.659 4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659z"></path>
-                </svg>
-                <a href="/" class="document-metadata-table__expand">Show More</a>
-              </th>
+            <tr id="show-more-metadata-row">
+              <td>
+                <a id="show-more-metadata-link" href="#"><i class="bi bi-caret-down"></i><span>Show More</span></a>
+              </td>
               <td></td>
             </tr>
           </tfoot>
@@ -214,3 +202,32 @@
     </div>
   </div>
 </section>
+
+<script>
+  $(function() {
+    var setupMoreMetadataToggle = function(linkId, rowId) {
+
+      // Wire the link to toggle between show more/show less
+      $(linkId).click(function() {
+        if ($(linkId).text() == "Show Less") {
+          $(".toggable-row").toggleClass("hidden-row");
+          $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
+          $(linkId + " span").text("Show More");
+        } else {
+          $(".toggable-row").toggleClass("hidden-row");
+          $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
+          $(linkId + " span").text("Show Less");
+        }
+        return false;
+      });
+
+      // Remove the toogle link if there is nothing to toggle.
+      var hideToogleLink = $(".toggable-row.hidden-row").length == 0;
+      if (hideToogleLink) {
+        $(rowId).addClass("hidden-row");
+      }
+    }
+
+    setupMoreMetadataToggle("#show-more-metadata-link", "#show-more-metadata-row");
+  });
+</script>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -8,9 +8,9 @@
   <table>
     <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
     <% @document.license.each do |license| %>
-      <%= render_field_row "License: ", license, true %>
+      <%= render_sidebar_row "License: ", license %>
     <% end %>
     <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
-    <%= render_field_row "File Types: ", file_counts.join(", "), true %>
+    <%= render_sidebar_row "File Types: ", file_counts.join(", ") %>
   </table>
 </div>


### PR DESCRIPTION
Adds the ability to show more or less fields in the metadata section of the Show page. By default only the fields indicated in issue #34 are shown to the user.

I also updated the code to display singular/plural headings (e.g. Author vs Authors, Genre vs Genres) depending of the number of values.

I made a few of the elements display as comma delimited lists as well (rather than each value on its own row). I think makes the display more pleasant. Feedback appreciated.

Closes #34 

## Default fields displayed
![show_more](https://user-images.githubusercontent.com/568286/151878166-b9de9a54-ca20-468c-a88c-6a5d1e5b8be0.png)

## All fields displayed
![show_less](https://user-images.githubusercontent.com/568286/151878198-929fdd8a-0e17-4845-90c2-f82fc918bb44.png)

