### PR TITLE
Display DOI in the sidebar and adds copy to clipboard button

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -40,3 +40,13 @@
   text-overflow: ellipsis;
   text-align: left;
 }
+
+.copy-doi-label-normal {
+  font-size: 8pt;
+  color: #212529;
+}
+
+.copy-doi-label-copied {
+  font-size: 8pt;
+  color: green;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # rubocop:disable Rails/OutputSafety
+# rubocop:disable Metrics/ModuleLength
 module ApplicationHelper
   # Outputs the HTML to render a single value as an HTML table row
   # to be displayed on the metadata section of the show page.
@@ -85,6 +86,26 @@ module ApplicationHelper
     html.html_safe
   end
 
+  # Outputs the HTML to render the DOI as an HTML table row to be
+  # displayed on the sidebar with a copy to clipboard button next to it.
+  def render_sidebar_doi_row(url, value)
+    return if url.nil?
+    tooltip = "Copy DOI URL to the clipboard"
+    html = <<-HTML
+    <tr>
+      <th scope="row" class="sidebar-label"><span>DOI:</span></th>
+      <td class="sidebar-value">
+        <span>#{link_to(value, url, target: '_blank', rel: 'noopener noreferrer')}</span>
+        <button id="copy-doi" class="btn btn-sm" data-url="#{url}" title="#{tooltip}">
+          <i id="copy-doi-icon" class="bi bi-clipboard" title="#{tooltip}"></i>
+          <span id="copy-doi-label" class="copy-doi-label-normal">COPY</span>
+        </button>
+      </td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
   # Outputs the HTML to render a list of subjects
   # (this is used on the sidebar)
   def render_subject_search_links(title, values, field)
@@ -117,3 +138,4 @@ module ApplicationHelper
   end
 end
 # rubocop:enable Rails/OutputSafety
+# rubocop:enable Metrics/ModuleLength

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -149,6 +149,17 @@ class SolrDocument
     fetch("uri_tesim", [])
   end
 
+  def doi_url
+    uri.each do |link|
+      return link if link.downcase.start_with?('https://doi.org/')
+    end
+    nil
+  end
+
+  def doi_value
+    doi_url&.gsub('https://doi.org/', '')
+  end
+
   def format
     fetch("format_ssim", [])
   end

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -12,5 +12,46 @@
     <% end %>
     <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
     <%= render_sidebar_row "File Types: ", file_counts.join(", ") %>
+    <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>
   </table>
 </div>
+
+<script>
+  $(function() {
+    var setupCopyDoiToClipboard = function(linkId, textId) {
+
+      $("#copy-doi").click(function(x) {
+        var doi = this.dataset["url"];
+        // Copy value to the clipboard...
+        navigator.clipboard.writeText(doi).then(function() {
+          // ...and let the user know
+          $("#copy-doi-icon").removeClass("bi-clipboard");
+          $("#copy-doi-icon").addClass("bi-clipboard-check");
+          $("#copy-doi-label").text("COPIED");
+          $("#copy-doi-label").removeClass("copy-doi-label-normal");
+          $("#copy-doi-label").addClass("copy-doi-label-copied");
+          setTimeout(function() {
+            // ...after 20 seconds reset display to normal
+            $("#copy-doi-label").text("COPY");
+            $("#copy-doi-label").removeClass("copy-doi-label-copied");
+            $("#copy-doi-label").addClass("copy-doi-label-normal");
+            $("#copy-doi-icon").addClass("bi-clipboard");
+            $("#copy-doi-icon").removeClass("bi-clipboard-check");
+          }, 20000);
+        }, function() {
+          // ...something went wrong
+          $("#copy-doi-icon").removeClass("bi-clipboard");
+          $("#copy-doi-icon").addClass("bi-clipboard-minus")
+          console.log("Copy to clipboard failed");
+        });
+        // Clear focus from the button.
+        document.activeElement.blur();
+        return false;
+      });
+
+    }
+
+    setupCopyDoiToClipboard();
+  });
+
+</script>


### PR DESCRIPTION
Notice that I am displaying the DOI **value** (so that it fits nicely on the sidebar) but I am copying the **full URL** to the clipboard when the user clicks on the `COPY` icon.

![copy-to-clipboard](https://user-images.githubusercontent.com/568286/152041315-a931fed0-15c5-4e4b-b7a9-4f71b456689b.png)

![copied-to-clipboard](https://user-images.githubusercontent.com/568286/152041329-527a04d2-570e-4d06-b283-5329d5a710cd.png)

Closes #36 