### PR TITLE
Display license as hyperlink in the sidebar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,6 +106,27 @@ module ApplicationHelper
     html.html_safe
   end
 
+  def render_sidebar_licenses(licenses)
+    return if licenses.count.zero?
+
+    licenses_html = licenses.map do |license|
+      url = License.url(license)
+      if url.nil?
+        "<span>#{html_escape(license)}</span>"
+      else
+        "<span>" + link_to(license, url, target: '_blank', rel: 'noopener noreferrer') + "</span>"
+      end
+    end
+
+    html = <<-HTML
+    <tr>
+      <th scope="row" class="sidebar-label"><span>#{'License'.pluralize(licenses.count)}:</span></th>
+      <td class="sidebar-value">#{licenses_html.join('<br/>')}</td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
   # Outputs the HTML to render a list of subjects
   # (this is used on the sidebar)
   def render_subject_search_links(title, values, field)

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class License
+  def self.url(license_type)
+    case normalize_type(license_type)
+    when 'cc0 license'
+      'https://creativecommons.org/publicdomain/zero/1.0/'
+    end
+  end
+
+  def self.normalize_type(license_type)
+    return nil if license_type.nil?
+    license_type.downcase.strip
+  end
+end

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -6,10 +6,8 @@
 
 <div id="sidebar-keywords" class="sidebar">
   <table>
+    <%= render_sidebar_licenses @document.license %>
     <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
-    <% @document.license.each do |license| %>
-      <%= render_sidebar_row "License: ", license %>
-    <% end %>
     <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
     <%= render_sidebar_row "File Types: ", file_counts.join(", ") %>
     <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe License do
+  describe 'url' do
+    it 'handles minor variations' do
+      expect(described_class.url('CC0 License')).to eq 'https://creativecommons.org/publicdomain/zero/1.0/'
+      expect(described_class.url('CC0 license')).to eq 'https://creativecommons.org/publicdomain/zero/1.0/'
+    end
+
+    it 'handles unknown licenses' do
+      expect(described_class.url('blah blah')).to be nil
+      expect(described_class.url(nil)).to be nil
+    end
+  end
+end


### PR DESCRIPTION
Displays **known** licenses as hyperlinks in the sidebar. Unknown licenses will be displayed as plain text.

## Known license
![cc0](https://user-images.githubusercontent.com/568286/152056934-5b534cdf-a131-4920-877b-a252915890b2.png)

## Unknown license
![unknown](https://user-images.githubusercontent.com/568286/152056941-e1a73bc3-8bff-4e4c-812c-fc1b0533a0a1.png)

Closes #42 