### PR TITLE
Renders citation and allows copy to clipboard

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -53,7 +53,7 @@
 
 /* A smaller version of Bootstrap's `btn-sm` */
 .btn-xsm {
-  padding: 0.0rem 0.5rem;
+  padding: 0rem 0.5rem;
   font-size: 0.775rem;
   line-height: 1.5;
   border-radius: 0.2rem;

--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -50,3 +50,11 @@
   font-size: 8pt;
   color: green;
 }
+
+/* A smaller version of Bootstrap's `btn-sm` */
+.btn-xsm {
+  padding: 0.0rem 0.5rem;
+  font-size: 0.775rem;
+  line-height: 1.5;
+  border-radius: 0.2rem;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,6 +127,44 @@ module ApplicationHelper
     html.html_safe
   end
 
+  # Renders the menu with the different citation options that we support
+  def render_sidebar_citation_options(prefered_style)
+    html_buttons = DatasetCitation.styles.map do |style|
+      css_class = style == prefered_style ? "btn-outline-primary" : "btn-outline-secondary"
+      tooltip = "Show citation as #{style}"
+      "<button type='button' data-style='#{style}' class='cite-as-button btn #{css_class} btn-xsm' title='#{tooltip}'>#{style}</button>&nbsp;"
+    end
+
+    html = <<-HTML
+    <tr>
+      <th scope="row" class="sidebar-label"><span>Cite as:</span></th>
+      <td class="sidebar-value">#{html_buttons.join}</td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
+  # Renders a citation in the given style
+  # (notice that only the citation in the preferred style marked as visible)
+  def render_sidebar_citation(citation, style, preferred_style)
+    return if citation.nil?
+    css_class = style == preferred_style ? 'citation-row' : 'citation-row hidden-row'
+    tooltip = 'Copy citation to the clipboard'
+
+    html = <<-HTML
+    <tr class="#{css_class}" data-style="#{style}">
+      <th scope="row" class="sidebar-label"><span></span></th>
+      <td class="sidebar-value">#{html_escape(citation)}
+        <button class="copy-citation-button btn btn-sm" data-style="#{style}" data-text="#{html_escape(citation)}" title="#{tooltip}">
+          <i class="bi bi-clipboard" title="#{tooltip}"></i>
+          <span class="copy-citation-label-normal">COPY</span>
+        </button>
+      </td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
   # Outputs the HTML to render a list of subjects
   # (this is used on the sidebar)
   def render_subject_search_links(title, values, field)

--- a/app/models/dataset_citation.rb
+++ b/app/models/dataset_citation.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Handles citations for datasets
+# rubocop:disable Metrics/ParameterLists
+class DatasetCitation
+  def self.styles
+    ["APA", "Chicago"]
+  end
+
+  # @param authors [<String>] Array of authors.
+  # @param years [<String>] Array of years (expected 1 or 2 values).
+  # @param title [String>] Title of the dataset
+  # @param type [String] Type of the dataset (e.g. "Data set" or "Unpublished raw data")
+  # @publisher [String] Publisher of the dataset
+  # @doi [String] DOI URL
+  def initialize(authors, years, title, type, publisher, doi)
+    @authors = authors || []
+    @years = years || []
+    @title = title
+    @type = type
+    @publisher = publisher
+    @doi = doi
+  end
+
+  def to_s(style)
+    if style == "Chicago"
+      chicago
+    else
+      apa
+    end
+  end
+
+  # Returns a string with APA citation for the dataset
+  # Reference: https://libguides.usc.edu/APA7th/datasets#s-lg-box-22855503
+  def apa
+    apa_author = ''
+    case @authors.count
+    when 0
+      # do nothing
+    when 1
+      apa_author += @authors.first
+    when 2
+      apa_author += @authors.join(' & ')
+    else
+      apa_author += @authors[0..-2].join(', ') + ', & ' + @authors[-1]
+    end
+
+    apa_year = ''
+    case @years.count
+    when 0
+      # do nothing
+    when 1
+      apa_year += "(#{@years.first})"
+    else
+      apa_year += "(#{@years.join('-')})"
+    end
+
+    apa_title = DatasetCitation.custom_strip(@title)
+    apa_title += " [#{@type}]" if @type.present?
+    apa_title = append_dot(apa_title)
+
+    apa_publisher = append_dot(@publisher)
+    apa_doi = @doi
+
+    tokens = [append_dot(apa_author), append_dot(apa_year), apa_title, apa_publisher, apa_doi].reject(&:blank?)
+    tokens.join(' ')
+  rescue => ex
+    Rails.logger.error "Error generating APA citation for (#{@title}): #{ex.message}"
+    nil
+  end
+
+  # Returns a string with Chicago citation for the dataset
+  # Reference: https://libguides.webster.edu/data/chicago
+  def chicago
+    chi_author = ''
+    case @authors.count
+    when 0
+      # do nothing
+    when 1
+      chi_author += @authors.first
+    when 2
+      chi_author += @authors.join(' and ')
+    else
+      chi_author += @authors[0..-2].join(', ') + ' and ' + @authors[-1]
+    end
+
+    chi_year = @years.count.zero? ? '' : append_dot(@years.join('-'))
+
+    chi_title = append_dot(@title)
+    chi_publisher = append_dot(@publisher)
+    chi_doi = append_dot(@doi)
+
+    tokens = [append_dot(chi_author), chi_title, chi_year, chi_publisher, chi_doi].reject(&:blank?)
+    tokens.join(' ')
+  rescue => ex
+    Rails.logger.error "Error generating Chicago citation for (#{@title}): #{ex.message}"
+    nil
+  end
+
+  # Appends a dot to a string if it does not end with one.
+  def append_dot(value)
+    return nil if value.nil?
+    return '' if value.empty?
+    DatasetCitation.custom_strip(value) + '.'
+  end
+
+  # Strip a few specific characters that tend to mess up citations (e.g. trailing periods, commas, et cetera)
+  def self.custom_strip(value)
+    return nil if value.nil?
+    return '' if value.empty?
+    while true
+      last_char = value[-1]
+      break if last_char.nil? || !last_char.in?('. ,')
+      value = value.chomp(last_char)
+    end
+    value
+  end
+end
+# rubocop:enable Metrics/ParameterLists

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -445,5 +445,17 @@ class SolrDocument
   def icon_css
     ICONS[genre&.downcase] || 'bi-file-earmark-fill'
   end
+
+  def prefered_citation
+    # Hard-coded to APA until we allow researchers to store a prefered citation for their dataset
+    "APA"
+  end
+
+  def cite(style)
+    year_available = fetch('year_available_itsi', nil)
+    years = year_available ? [year_available.to_s] : []
+    citation = DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
+    citation.to_s(style)
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -3,7 +3,7 @@
     <div class="card">
       <div class="document-metadata-table card-body">
         <header>More about this record</header>
-        <table class="table">
+        <table id="metadata-table" class="table">
           <thead></thead>
           <tbody>
             <%= render_field_row_many "Alternative Title", @document.alternative_title %>
@@ -210,11 +210,11 @@
       // Wire the link to toggle between show more/show less
       $(linkId).click(function() {
         if ($(linkId).text() == "Show Less") {
-          $(".toggable-row").toggleClass("hidden-row");
+          $("#metadata-table .toggable-row").toggleClass("hidden-row");
           $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
           $(linkId + " span").text("Show More");
         } else {
-          $(".toggable-row").toggleClass("hidden-row");
+          $("#metadata-table .toggable-row").toggleClass("hidden-row");
           $(linkId + " i").toggleClass("bi-caret-up bi-caret-down");
           $(linkId + " span").text("Show Less");
         }

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -22,9 +22,6 @@
   $(function() {
 
     // Sets the elements to the proper CSS classes once a value has been copied to the clipboard.
-    // iconEl - selector for the HTML element with the clipboard icon
-    // labelEl - selector for the HTML element with the COPY label next to the icon
-    // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference to an element)
     var setCopiedToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
       $(iconEl).removeClass("bi-clipboard");
       $(iconEl).addClass("bi-clipboard-check");
@@ -49,22 +46,32 @@
       console.log(errorMsg);
     }
 
-    var setupCopyDoiToClipboard = function(linkId, textId) {
-      $("#copy-doi").click(function(_x) {
-        var doi = this.dataset["url"];
+    // Copies a value to the clipboard and notifies the user
+    // value - value to copy to the clipboard
+    // iconEl - selector for the HTML element with the clipboard icon
+    // labelEl - selector for the HTML element with the COPY label next to the icon
+    // normalClass - CSS to style the label with initially
+    // copiedClass - CSS to style the label with after a value has been copied to the clipboard
+    // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference to an element)
+    var copyToClipboard = function(value, iconEl, labelEl, normalClass, copiedClass) {
         // Copy value to the clipboard....
-        navigator.clipboard.writeText(doi).then(function() {
-          // ...notify the user
-          setCopiedToClipboard("#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
+        navigator.clipboard.writeText(value).then(function() {
+          // ...and notify the user
+          setCopiedToClipboard(iconEl, labelEl, normalClass, copiedClass);
           setTimeout(function() {
-            // ...clear notification after 20 seconds
-            resetCopyToClipboard("#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
+            resetCopyToClipboard(iconEl, labelEl, normalClass, copiedClass);
           }, 20000);
         }, function() {
-          errorCopyToClipboard("#copy-doi-icon", "Copy DOI to the clipboard failed");
+          errorCopyToClipboard(iconEl, "Copy to clipboard failed");
         });
         // Clear focus from the button.
         document.activeElement.blur();
+    }
+
+    var setupCopyDoiToClipboard = function() {
+      $("#copy-doi").click(function(_x) {
+        var doi = this.dataset["url"];
+        copyToClipboard(doi, "#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
         return false;
       });
     }
@@ -104,20 +111,7 @@
         var icon = $(this).children("i");
         var label = $(this).children("span");
         var citation = this.dataset["text"];
-        // Copy value to the clipboard...
-        navigator.clipboard.writeText(citation).then(function() {
-          // ...notify the user
-          setCopiedToClipboard(icon, label, "copy-doi-label-normal", "copy-doi-label-copied");
-          setTimeout(function() {
-            // ...clear notification after 20 seconds
-            resetCopyToClipboard(icon, label, "copy-doi-label-normal", "copy-doi-label-copied");
-          }, 20000);
-        }, function() {
-          // ...something went wrong
-          errorCopyToClipboard(icon, "Copy citation to the clipboard failed");
-        });
-        // Clear focus from the button.
-        document.activeElement.blur();
+        copyToClipboard(citation, icon, label, "copy-doi-label-normal", "copy-doi-label-copied");
         return false;
       });
     }

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -20,31 +20,43 @@
 
 <script>
   $(function() {
+
+    var setCopiedToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
+      $(iconEl).removeClass("bi-clipboard");
+      $(iconEl).addClass("bi-clipboard-check");
+      $(labelEl).text("COPIED");
+      $(labelEl).removeClass(normalClass);
+      $(labelEl).addClass(copiedClass);
+    }
+
+    var resetCopyToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
+      $(labelEl).text("COPY");
+      $(labelEl).removeClass(copiedClass);
+      $(labelEl).addClass(normalClass);
+      $(iconEl).addClass("bi-clipboard");
+      $(iconEl).removeClass("bi-clipboard-check");
+    }
+
+    var errorCopyToClipboard = function(iconEl, errorMsg) {
+      $(iconEl).removeClass("bi-clipboard");
+      $(iconEl).addClass("bi-clipboard-minus")
+      console.log(errorMsg);
+    }
+
     var setupCopyDoiToClipboard = function(linkId, textId) {
 
       $("#copy-doi").click(function(_x) {
         var doi = this.dataset["url"];
-        // Copy value to the clipboard...
+        // Copy value to the clipboard....
         navigator.clipboard.writeText(doi).then(function() {
-          // ...and let the user know
-          $("#copy-doi-icon").removeClass("bi-clipboard");
-          $("#copy-doi-icon").addClass("bi-clipboard-check");
-          $("#copy-doi-label").text("COPIED");
-          $("#copy-doi-label").removeClass("copy-doi-label-normal");
-          $("#copy-doi-label").addClass("copy-doi-label-copied");
+          // ...notify the user
+          setCopiedToClipboard("#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
           setTimeout(function() {
-            // ...after 20 seconds reset display to normal
-            $("#copy-doi-label").text("COPY");
-            $("#copy-doi-label").removeClass("copy-doi-label-copied");
-            $("#copy-doi-label").addClass("copy-doi-label-normal");
-            $("#copy-doi-icon").addClass("bi-clipboard");
-            $("#copy-doi-icon").removeClass("bi-clipboard-check");
+            // ...clear notification after 20 seconds
+            resetCopyToClipboard("#copy-doi-icon", "#copy-doi-label", "copy-doi-label-normal", "copy-doi-label-copied");
           }, 20000);
         }, function() {
-          // ...something went wrong
-          $("#copy-doi-icon").removeClass("bi-clipboard");
-          $("#copy-doi-icon").addClass("bi-clipboard-minus")
-          console.log("Copy DOI to the clipboard failed");
+          errorCopyToClipboard("#copy-doi-icon", "Copy DOI to the clipboard failed");
         });
         // Clear focus from the button.
         document.activeElement.blur();

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -5,12 +5,16 @@
 </div>
 
 <div id="sidebar-keywords" class="sidebar">
-  <table>
+  <table id="sidebar-table">
     <%= render_sidebar_licenses @document.license %>
     <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
     <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
     <%= render_sidebar_row "File Types: ", file_counts.join(", ") %>
     <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>
+    <%= render_sidebar_citation_options @document.prefered_citation %>
+    <% DatasetCitation.styles.each do |style| %>
+      <%= render_sidebar_citation @document.cite(style), style, @document.prefered_citation %>
+    <% end %>
   </table>
 </div>
 
@@ -18,7 +22,7 @@
   $(function() {
     var setupCopyDoiToClipboard = function(linkId, textId) {
 
-      $("#copy-doi").click(function(x) {
+      $("#copy-doi").click(function(_x) {
         var doi = this.dataset["url"];
         // Copy value to the clipboard...
         navigator.clipboard.writeText(doi).then(function() {
@@ -40,7 +44,72 @@
           // ...something went wrong
           $("#copy-doi-icon").removeClass("bi-clipboard");
           $("#copy-doi-icon").addClass("bi-clipboard-minus")
-          console.log("Copy to clipboard failed");
+          console.log("Copy DOI to the clipboard failed");
+        });
+        // Clear focus from the button.
+        document.activeElement.blur();
+        return false;
+      });
+
+    }
+
+    var setupCitationToggle = function() {
+      $(".cite-as-button").click(function(_x) {
+        var style_selected = this.dataset["style"];
+
+        // Make visible the selected style...
+        $(".citation-row").each(function(_i, value) {
+          if (value.dataset["style"] == style_selected) {
+            $(value).removeClass("hidden-row");
+          } else {
+            $(value).addClass("hidden-row");
+          }
+        });
+
+        // ...update the menu to reflect the active style
+        $(".cite-as-button").each(function(_i, value) {
+          if (value.dataset["style"] == style_selected) {
+            $(value).addClass("btn-outline-primary");
+            $(value).removeClass("btn-outline-secondary");
+          } else {
+            $(value).addClass("btn-outline-secondary");
+            $(value).removeClass("btn-outline-primary");
+          }
+        });
+
+        // Clear focus from the button.
+        document.activeElement.blur();
+        return false;
+      })
+    }
+
+    var setupCopyCitationToClipboard = function(linkId, textId) {
+
+      $(".copy-citation-button").click(function(_x) {
+        var icon = $(this).children("i");
+        var label = $(this).children("span");
+        var citation = this.dataset["text"];
+        // Copy value to the clipboard...
+        navigator.clipboard.writeText(citation).then(function() {
+          // ...and let the user know
+          $(icon).removeClass("bi-clipboard");
+          $(icon).addClass("bi-clipboard-check");
+          $(label).text("COPIED");
+          $(label).removeClass("copy-doi-label-normal");
+          $(label).addClass("copy-doi-label-copied");
+          setTimeout(function() {
+            // ...after 20 seconds reset display to normal
+            $(label).text("COPY");
+            $(label).removeClass("copy-doi-label-copied");
+            $(label).addClass("copy-doi-label-normal");
+            $(icon).addClass("bi-clipboard");
+            $(icon).removeClass("bi-clipboard-check");
+          }, 20000);
+        }, function() {
+          // ...something went wrong
+          $(icon).removeClass("bi-clipboard");
+          $(icon).addClass("bi-clipboard-minus")
+          console.log("Copy citation to the clipboard failed");
         });
         // Clear focus from the button.
         document.activeElement.blur();
@@ -50,6 +119,8 @@
     }
 
     setupCopyDoiToClipboard();
+    setupCitationToggle();
+    setupCopyCitationToClipboard();
   });
 
 </script>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -21,6 +21,10 @@
 <script>
   $(function() {
 
+    // Sets the elements to the proper CSS classes once a value has been copied to the clipboard.
+    // iconEl - selector for the HTML element with the clipboard icon
+    // labelEl - selector for the HTML element with the COPY label next to the icon
+    // iconEl and labelEl could be any jQuery valid selector (e.g. ".some-id" or a reference to an element)
     var setCopiedToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
       $(iconEl).removeClass("bi-clipboard");
       $(iconEl).addClass("bi-clipboard-check");
@@ -29,6 +33,7 @@
       $(labelEl).addClass(copiedClass);
     }
 
+    // Resets the elements to the proper CSS classes (e.g. displays as if the copy has not happened)
     var resetCopyToClipboard = function(iconEl, labelEl, normalClass, copiedClass) {
       $(labelEl).text("COPY");
       $(labelEl).removeClass(copiedClass);
@@ -37,6 +42,7 @@
       $(iconEl).removeClass("bi-clipboard-check");
     }
 
+    // Sets icon and label to indicate that an error happened when copying a value to the clipboard
     var errorCopyToClipboard = function(iconEl, errorMsg) {
       $(iconEl).removeClass("bi-clipboard");
       $(iconEl).addClass("bi-clipboard-minus")
@@ -44,7 +50,6 @@
     }
 
     var setupCopyDoiToClipboard = function(linkId, textId) {
-
       $("#copy-doi").click(function(_x) {
         var doi = this.dataset["url"];
         // Copy value to the clipboard....
@@ -62,7 +67,6 @@
         document.activeElement.blur();
         return false;
       });
-
     }
 
     var setupCitationToggle = function() {
@@ -96,38 +100,26 @@
     }
 
     var setupCopyCitationToClipboard = function(linkId, textId) {
-
       $(".copy-citation-button").click(function(_x) {
         var icon = $(this).children("i");
         var label = $(this).children("span");
         var citation = this.dataset["text"];
         // Copy value to the clipboard...
         navigator.clipboard.writeText(citation).then(function() {
-          // ...and let the user know
-          $(icon).removeClass("bi-clipboard");
-          $(icon).addClass("bi-clipboard-check");
-          $(label).text("COPIED");
-          $(label).removeClass("copy-doi-label-normal");
-          $(label).addClass("copy-doi-label-copied");
+          // ...notify the user
+          setCopiedToClipboard(icon, label, "copy-doi-label-normal", "copy-doi-label-copied");
           setTimeout(function() {
-            // ...after 20 seconds reset display to normal
-            $(label).text("COPY");
-            $(label).removeClass("copy-doi-label-copied");
-            $(label).addClass("copy-doi-label-normal");
-            $(icon).addClass("bi-clipboard");
-            $(icon).removeClass("bi-clipboard-check");
+            // ...clear notification after 20 seconds
+            resetCopyToClipboard(icon, label, "copy-doi-label-normal", "copy-doi-label-copied");
           }, 20000);
         }, function() {
           // ...something went wrong
-          $(icon).removeClass("bi-clipboard");
-          $(icon).addClass("bi-clipboard-minus")
-          console.log("Copy citation to the clipboard failed");
+          errorCopyToClipboard(icon, "Copy citation to the clipboard failed");
         });
         // Clear focus from the button.
         document.activeElement.blur();
         return false;
       });
-
     }
 
     setupCopyDoiToClipboard();

--- a/spec/models/dataset_citation_spec.rb
+++ b/spec/models/dataset_citation_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable Layout/LineLength
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe DatasetCitation do
+  let(:single_author_dataset) { described_class.new(["Menard, J.E."], [2018], "Compact steady-state tokamak", "Data set", "Princeton University", "http://doi.org/princeton/test123") }
+  let(:two_authors_dataset) { described_class.new(["Menard, J.E.", "Lopez, R."], [2018], "Compact steady-state tokamak", "Data set", "Princeton University", "http://doi.org/princeton/test123") }
+  let(:three_authors_dataset) { described_class.new(["Menard, J.E.", "Lopez, R.", "Liu, D."], [2018], "Compact steady-state tokamak", "Data set", "Princeton University", "http://doi.org/princeton/test123") }
+
+  describe "#apa" do
+    it "handles authors correctly" do
+      expect(single_author_dataset.apa).to eq "Menard, J.E. (2018). Compact steady-state tokamak [Data set]. Princeton University. http://doi.org/princeton/test123"
+      expect(two_authors_dataset.apa).to eq "Menard, J.E. & Lopez, R. (2018). Compact steady-state tokamak [Data set]. Princeton University. http://doi.org/princeton/test123"
+      expect(three_authors_dataset.apa).to eq "Menard, J.E., Lopez, R., & Liu, D. (2018). Compact steady-state tokamak [Data set]. Princeton University. http://doi.org/princeton/test123"
+    end
+  end
+
+  describe "#chicago" do
+    it "handles authors correctly" do
+      expect(single_author_dataset.chicago).to eq "Menard, J.E. Compact steady-state tokamak. 2018. Princeton University. http://doi.org/princeton/test123."
+      expect(two_authors_dataset.chicago).to eq "Menard, J.E. and Lopez, R. Compact steady-state tokamak. 2018. Princeton University. http://doi.org/princeton/test123."
+      expect(three_authors_dataset.chicago).to eq "Menard, J.E., Lopez, R. and Liu, D. Compact steady-state tokamak. 2018. Princeton University. http://doi.org/princeton/test123."
+    end
+  end
+
+  describe "title" do
+    it "does not add extra periods to title and publisher if they come in the source data" do
+      citation = described_class.new(["Menard, J.E."], [2018], "Compact steady-state tokamak.", "Data set", "Princeton University.", "http://doi.org/princeton/test123")
+      expect(citation.apa).to eq "Menard, J.E. (2018). Compact steady-state tokamak [Data set]. Princeton University. http://doi.org/princeton/test123"
+      expect(citation.chicago).to eq "Menard, J.E. Compact steady-state tokamak. 2018. Princeton University. http://doi.org/princeton/test123."
+    end
+  end
+
+  describe "year" do
+    it "handles year ranges" do
+      citation = described_class.new(["Menard, J.E."], [2018, 2020], "Compact steady-state tokamak.", "Data set", "Princeton University.", "http://doi.org/princeton/test123")
+      expect(citation.apa).to eq "Menard, J.E. (2018-2020). Compact steady-state tokamak [Data set]. Princeton University. http://doi.org/princeton/test123"
+      expect(citation.chicago).to eq "Menard, J.E. Compact steady-state tokamak. 2018-2020. Princeton University. http://doi.org/princeton/test123."
+    end
+  end
+
+  describe "#custom_strip" do
+    it "custom trailing characters" do
+      expect(described_class.custom_strip("Some title.")).to eq "Some title"
+      expect(described_class.custom_strip("Some title..")).to eq "Some title"
+      expect(described_class.custom_strip("Some title")).to eq "Some title"
+      expect(described_class.custom_strip("Some title, ")).to eq "Some title"
+      expect(described_class.custom_strip("Some title, .")).to eq "Some title"
+      expect(described_class.custom_strip("")).to eq ""
+      expect(described_class.custom_strip(nil)).to eq nil
+      expect(described_class.custom_strip(" . , ")).to eq ""
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength
+# rubocop:enable Layout/LineLength

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -16,4 +16,13 @@ describe 'Single item page', type: :system, js: true do
     visit '/catalog/78348'
     expect(page).to have_content "Midplane neutral density profiles in the National Spherical Torus Experiment"
   end
+
+  # rubocop:disable Layout/LineLength
+  it "has expected citation information" do
+    visit '/catalog/78348'
+    apa_citation = "Stotler, D., F. Scotti, R.E. Bell, A. Diallo, B.P. LeBlanc, M. Podesta, A.L. Roquemore, & P.W. Ross. (2016). Midplane neutral density profiles in the National Spherical Torus Experiment [Data set]. Princeton Plasma Physics Laboratory, Princeton University."
+    expect(page).to have_css 'tr.citation-row'
+    expect(page).to have_content apa_citation
+  end
+  # rubocop:enable Layout/LineLength
 end


### PR DESCRIPTION
Renders citation information in ALA or Chicago and allows the user to copy the citation text to the clipboard.

## APA style
![apa_style](https://user-images.githubusercontent.com/568286/152249828-19b5e6ef-5a1f-406d-aa80-4e7412188266.png)

## Chicago style
![chicago_style](https://user-images.githubusercontent.com/568286/152249853-04e1a620-b7ef-4343-94f9-b51471f917f4.png)

Closes #75 
