### PR TITLE
Adds support for BibTex citations

### DIFF
--- a/app/assets/stylesheets/components/sidebar.scss
+++ b/app/assets/stylesheets/components/sidebar.scss
@@ -51,6 +51,10 @@
   color: green;
 }
 
+.copy-citation-label-normal {
+  font-size: 8pt;
+}
+
 /* A smaller version of Bootstrap's `btn-sm` */
 .btn-xsm {
   padding: 0rem 0.5rem;

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,4 +207,11 @@ class CatalogController < ApplicationController
     # default 'mySuggester', uncomment and provide it below
     # config.autocomplete_suggester = 'mySuggester'
   end
+
+  # Returns the raw BibTex citation information
+  def bibtex
+    _unused, @document = search_service.fetch(params[:id])
+    citation = @document.cite("BibTeX")
+    send_data citation, filename: "#{@document.bibtex_id}.bibtex", type: 'text/plain', disposition: 'attachment'
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,10 +146,20 @@ module ApplicationHelper
 
   # Renders a citation in the given style
   # (notice that only the citation in the preferred style marked as visible)
-  def render_sidebar_citation(citation, style, preferred_style)
+  def render_sidebar_citation(citation, style, preferred_style, id)
     return if citation.nil?
     css_class = style == preferred_style ? 'citation-row' : 'citation-row hidden-row'
     tooltip = 'Copy citation to the clipboard'
+
+    download_button = ""
+    if style == "BibTeX"
+      download_button = <<-HTML
+        <button id="download-bibtex" class="btn btn-sm" data-url="#{catalog_bibtex_url(id:id)}">
+          <i class="bi bi-file-arrow-down" title="Download citation"></i>
+          <span class="copy-citation-label-normal">DOWNLOAD</span>
+        </button>
+      HTML
+    end
 
     html = <<-HTML
     <tr class="#{css_class}" data-style="#{style}">
@@ -159,6 +169,7 @@ module ApplicationHelper
           <i class="bi bi-clipboard" title="#{tooltip}"></i>
           <span class="copy-citation-label-normal">COPY</span>
         </button>
+        #{download_button}
       </td>
     </tr>
     HTML

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,7 +154,7 @@ module ApplicationHelper
     download_button = ""
     if style == "BibTeX"
       download_button = <<-HTML
-        <button id="download-bibtex" class="btn btn-sm" data-url="#{catalog_bibtex_url(id:id)}">
+        <button id="download-bibtex" class="btn btn-sm" data-url="#{catalog_bibtex_url(id: id)}">
           <i class="bi bi-file-arrow-down" title="Download citation"></i>
           <span class="copy-citation-label-normal">DOWNLOAD</span>
         </button>

--- a/app/models/dataset_citation.rb
+++ b/app/models/dataset_citation.rb
@@ -139,6 +139,41 @@ class DatasetCitation
     nil
   end
 
+  # Return a string with the ContextObjects in Spans (COinS) information
+  # https://en.wikipedia.org/wiki/COinS
+  def coins
+    tokens = []
+    tokens << "url_ver=Z39.88-2004"
+    tokens << "ctx_ver=Z39.88-2004"
+    tokens << "rft.type=webpage"
+    tokens << "rft_val_fmt=#{CGI.escape('info:ofi/fmt:kev:mtx:dc')}"
+
+    if @title.present?
+      tokens << "rft.title=#{CGI.escape(@title)}"
+    end
+
+    @authors.each do |author|
+      tokens << "rft.au=#{CGI.escape(author)}"
+    end
+
+    if @years.count > 0
+      tokens << "rft.date=#{CGI.escape(@years.first.to_s)}"
+    end
+
+    if @publisher.present?
+      tokens << "rft.publisher=#{CGI.escape(@publisher)}"
+    end
+
+    if @doi.present?
+      tokens << "rft.identifier=#{CGI.escape(@doi)}"
+    end
+
+    "<span class=\"Z3988\" title=\"#{tokens.join('&amp;')}\"></span>"
+  rescue => ex
+    Rails.logger.error "Error generating COinS citation for (#{@title}): #{ex.message}"
+    nil
+  end
+
   # Returns an ID value for a BibTex citation
   def bibtex_id
     author_id = 'unknown'

--- a/app/models/dataset_citation.rb
+++ b/app/models/dataset_citation.rb
@@ -2,6 +2,9 @@
 
 # Handles citations for datasets
 # rubocop:disable Metrics/ParameterLists
+# rubocop:disable Metrics/ClassLength
+# rubocop:disable Style/NumericPredicate
+# rubocop:disable Style/IfUnlessModifier
 class DatasetCitation
   def self.styles
     ["APA", "Chicago", "BibTeX"]
@@ -140,7 +143,7 @@ class DatasetCitation
   def bibtex_id
     author_id = 'unknown'
     if @authors.count > 0
-      author_id = @authors.first.downcase.gsub(' ','_').gsub(/[^a-z0-9_]/,"")
+      author_id = @authors.first.downcase.tr(' ', '_').gsub(/[^a-z0-9_]/, '')
     end
     year_id = @years.first&.to_s || 'unknown'
     "#{author_id}_#{year_id}"
@@ -166,3 +169,6 @@ class DatasetCitation
   end
 end
 # rubocop:enable Metrics/ParameterLists
+# rubocop:enable Metrics/ClassLength
+# rubocop:enable Style/NumericPredicate
+# rubocop:enable Style/IfUnlessModifier

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -455,7 +455,7 @@ class SolrDocument
   def citation
     year_available = fetch('year_available_itsi', nil)
     years = year_available ? [year_available.to_s] : []
-    citation = DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
+    DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
   end
 
   # Returns a string with the indicated citation style (e.g. APA or Chicago)
@@ -464,8 +464,10 @@ class SolrDocument
   end
 
   # Returns the ID for a BibTex citation for this document.
+  # rubocop:disable Rails/Delegate
   def bibtex_id
     citation.bibtex_id
   end
+  # rubocop:enable Rails/Delegate
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -451,11 +451,21 @@ class SolrDocument
     "APA"
   end
 
-  def cite(style)
+  # Returns a DatasetCitation object for the current document
+  def citation
     year_available = fetch('year_available_itsi', nil)
     years = year_available ? [year_available.to_s] : []
     citation = DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
+  end
+
+  # Returns a string with the indicated citation style (e.g. APA or Chicago)
+  def cite(style)
     citation.to_s(style)
+  end
+
+  # Returns the ID for a BibTex citation for this document.
+  def bibtex_id
+    citation.bibtex_id
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -453,9 +453,11 @@ class SolrDocument
 
   # Returns a DatasetCitation object for the current document
   def citation
-    year_available = fetch('year_available_itsi', nil)
-    years = year_available ? [year_available.to_s] : []
-    DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
+    @citation ||= begin
+      year_available = fetch('year_available_itsi', nil)
+      years = year_available ? [year_available.to_s] : []
+      DatasetCitation.new(authors, years, title, 'Data set', publisher.first, doi_url)
+    end
   end
 
   # Returns a string with the indicated citation style (e.g. APA or Chicago)

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -13,7 +13,7 @@
     <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>
     <%= render_sidebar_citation_options @document.prefered_citation %>
     <% DatasetCitation.styles.each do |style| %>
-      <%= render_sidebar_citation @document.cite(style), style, @document.prefered_citation %>
+      <%= render_sidebar_citation @document.cite(style), style, @document.prefered_citation, @document.id %>
     <% end %>
   </table>
 </div>
@@ -116,9 +116,17 @@
       });
     }
 
+    var setupDownloadCitation = function() {
+      $("#download-bibtex").click(function (e) {
+        e.preventDefault();
+        window.location.href= this.dataset["url"];
+      });
+    }
+
     setupCopyDoiToClipboard();
     setupCitationToggle();
     setupCopyCitationToClipboard();
+    setupDownloadCitation();
   });
 
 </script>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -64,6 +64,9 @@
 
 </div>
 
+<!-- COinS citation information for Zotero and others -->
+<%= @document.citation.coins&.html_safe %>
+
 <%= render "show_sidebar" %>
 
 <script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   root to: 'catalog#index'
   concern :searchable, Blacklight::Routes::Searchable.new
 
+  get 'catalog/:id/bibtex' => 'catalog#bibtex', as: :catalog_bibtex
+
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable
     concerns :range_searchable

--- a/spec/models/dataset_citation_spec.rb
+++ b/spec/models/dataset_citation_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe DatasetCitation do
 
   describe "#bibtex" do
     it "returns correct format" do
-      bibtex = "@electronic{ menard_je_2018,\r\n" +
-      "  author = \"Menard, J.E.\",\r\n" +
-      "  title = \"Compact steady-state tokamak\",\r\n" +
-      "  publisher = \"Princeton University\",\r\n" +
-      "  year = \"2018\",\r\n" +
-      "  url = \"http://doi.org/princeton/test123\"\r\n" +
+      bibtex = "@electronic{ menard_je_2018,\r\n" \
+      "  author = \"Menard, J.E.\",\r\n" \
+      "  title = \"Compact steady-state tokamak\",\r\n" \
+      "  publisher = \"Princeton University\",\r\n" \
+      "  year = \"2018\",\r\n" \
+      "  url = \"http://doi.org/princeton/test123\"\r\n" \
       "}"
       expect(single_author_dataset.bibtex).to eq bibtex
     end

--- a/spec/models/dataset_citation_spec.rb
+++ b/spec/models/dataset_citation_spec.rb
@@ -25,6 +25,19 @@ RSpec.describe DatasetCitation do
     end
   end
 
+  describe "#bibtex" do
+    it "returns correct format" do
+      bibtex = "@electronic{ menard_je_2018,\r\n" +
+      "  author = \"Menard, J.E.\",\r\n" +
+      "  title = \"Compact steady-state tokamak\",\r\n" +
+      "  publisher = \"Princeton University\",\r\n" +
+      "  year = \"2018\",\r\n" +
+      "  url = \"http://doi.org/princeton/test123\"\r\n" +
+      "}"
+      expect(single_author_dataset.bibtex).to eq bibtex
+    end
+  end
+
   describe "title" do
     it "does not add extra periods to title and publisher if they come in the source data" do
       citation = described_class.new(["Menard, J.E."], [2018], "Compact steady-state tokamak.", "Data set", "Princeton University.", "http://doi.org/princeton/test123")

--- a/spec/models/dataset_citation_spec.rb
+++ b/spec/models/dataset_citation_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe DatasetCitation do
     end
   end
 
+  describe "#coins" do
+    it "returns correct format" do
+      coins = '<span class="Z3988" title="url_ver=Z39.88-2004&amp;ctx_ver=Z39.88-2004&amp;rft.type=webpage&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;' \
+      'rft.title=Compact+steady-state+tokamak&amp;rft.au=Menard%2C+J.E.&amp;rft.date=2018&amp;rft.publisher=Princeton+University&amp;' \
+      'rft.identifier=http%3A%2F%2Fdoi.org%2Fprinceton%2Ftest123"></span>'
+      expect(single_author_dataset.coins).to eq coins
+    end
+  end
+
   describe "title" do
     it "does not add extra periods to title and publisher if they come in the source data" do
       citation = described_class.new(["Menard, J.E."], [2018], "Compact steady-state tokamak.", "Data set", "Princeton University.", "http://doi.org/princeton/test123")

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -25,4 +25,9 @@ describe 'Single item page', type: :system, js: true do
     expect(page).to have_content apa_citation
   end
   # rubocop:enable Layout/LineLength
+
+  it "has expected HTML SPAN element with COinS information" do
+    visit '/catalog/78348'
+    expect(page.html.include?('<span class="Z3988"')).to be true
+  end
 end


### PR DESCRIPTION
Adds BibTex as a supported citation format. Includes support to download this citation format to a file since since that's a common approach to import them to citation management software like Zotero.

![bibtex](https://user-images.githubusercontent.com/568286/152607928-3e361b0e-288f-42ce-9144-705d12ead489.png)

## File Imported into Zotero
![zotero](https://user-images.githubusercontent.com/568286/152608346-1b9ef61d-d7b2-495c-9896-1a8bb15f55ba.png)


Closes #76 
