### PR TITLE
Rearranged facets

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -87,14 +87,14 @@ class CatalogController < ApplicationController
     # }
 
     config.add_facet_field 'domain_ssi', label: 'Domain'
-    config.add_facet_field 'author_ssim', label: 'Author'
-    config.add_facet_field 'genre_ssim', label: 'Genre'
-    config.add_facet_field 'subject_all_ssim', label: 'Subject'
-    config.add_facet_field 'publisher_ssim', label: 'Publisher'
-    config.add_facet_field 'year_available_itsi', label: 'Year Available', range: true
     config.add_facet_field 'community_root_name_ssi', label: 'Community'
     config.add_facet_field 'subcommunity_name_ssi', label: 'Subcommunity'
     config.add_facet_field 'collection_name_ssi', label: 'Collection'
+    config.add_facet_field 'author_ssim', label: 'Author', limit: true
+    config.add_facet_field 'genre_ssim', label: 'Type'
+    config.add_facet_field 'subject_all_ssim', label: 'Subject', limit: true
+    config.add_facet_field 'publisher_ssim', label: 'Publisher'
+    config.add_facet_field 'year_available_itsi', label: 'Year Published', range: true
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -53,5 +53,37 @@
 
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>
+
+<script>
+  $(function() {
+    // Returns the value for a given query string parameter.
+    // Source: https://css-tricks.com/snippets/javascript/get-url-variables/
+    var queryStringParam = function(name) {
+      var query = window.location.search.substring(1);
+      var vars = query.split("&");
+      for (var i=0; i<vars.length; i++) {
+        var pair = vars[i].split("=");
+        if (pair[0] == name){
+          return pair[1];
+        }
+      }
+      return(false);
+    }
+
+    // Returns the active facet value for a given field
+    var activeFacet = function(fieldName) {
+      return queryStringParam(encodeURI("f[" + fieldName + "][]"));
+    }
+
+    var hideFacetGroup = function(fieldName) {
+      $(`.blacklight-${fieldName}`).remove();
+    }
+
+    // Hide the subcommunity facet unless we are faceting by community or subcommunity.
+    if (!activeFacet("community_root_name_ssi") && !activeFacet("subcommunity_name_ssi")) {
+      hideFacetGroup("subcommunity_name_ssi");
+    }
+  });
+  </script>
 </body>
 <% end %>

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -76,9 +76,16 @@ end
 
 to_field 'author_tesim', extract_xpath("/item/metadata/key[text()='dc.contributor.author']/../value")
 
+# single value is used for sorting
 to_field 'author_si' do |record, accumulator, _c|
   values = record.xpath("/item/metadata/key[text()='dc.contributor.author']/../value").map(&:text)
   accumulator.concat [values.uniq.sort.first]
+end
+
+# all values as strings for faceting
+to_field 'author_ssim' do |record, accumulator, _c|
+  values = record.xpath("/item/metadata/key[text()='dc.contributor.author']/../value").map(&:text)
+  accumulator.concat values.uniq
 end
 
 # ==================

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -45,6 +45,7 @@ describe 'Search Results Page', type: :system, js: true do
     end
   end
 
+  # rubocop:disable RSpec/ExampleLength
   describe "facets" do
     it "shows expected facets" do
       visit '/?search_field=all_fields&q='
@@ -53,6 +54,13 @@ describe 'Search Results Page', type: :system, js: true do
 
       community_facet_html = '<div class="card facet-limit blacklight-community_root_name_ssi ">'
       expect(page.html.include?(community_facet_html)).to be true
+
+      type_facet_html = '<div class="card facet-limit blacklight-genre_ssim ">'
+      expect(page.html.include?(type_facet_html)).to be true
+
+      year_facet_html = '<div class="card facet-limit blacklight-year_available_itsi ">'
+      expect(page.html.include?(year_facet_html)).to be true
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -55,6 +55,9 @@ describe 'Search Results Page', type: :system, js: true do
       community_facet_html = '<div class="card facet-limit blacklight-community_root_name_ssi ">'
       expect(page.html.include?(community_facet_html)).to be true
 
+      author_facet_html = '<div class="card facet-limit blacklight-author_ssim ">'
+      expect(page.html.include?(author_facet_html)).to be true
+
       type_facet_html = '<div class="card facet-limit blacklight-genre_ssim ">'
       expect(page.html.include?(type_facet_html)).to be true
 


### PR DESCRIPTION
Updated the order in which facets are displayed as requested in #161 and included the proper Blacklight configuration to allow the user to view "more" facet values when there are more than 10. I also fixed a problem with Author facet that was using a non-existing field.

![facets](https://user-images.githubusercontent.com/568286/155169409-e3ebcf21-a198-4faf-a19e-15b44f1cf943.png)

Notice that the Subcommunity facet displays only when (1) the user filters by community and the community has subcommunities (in practice this means it only shows when the community is PPPL)

![facet_subcommunity](https://user-images.githubusercontent.com/568286/155170144-ab72aca6-ec67-41f8-9e8d-d4d5c966e5a1.png)

Closes #161 
