### PR TITLE
Display authors separated by semicolons in search results

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -103,7 +103,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_tesim', label: 'Author(s)'
+    config.add_index_field 'author_tesim', label: 'Author(s)', helper_method: :authors_search_results_helper
     config.add_index_field 'format', label: 'Format'
     config.add_index_field 'abstract_tsim', label: 'Abstract'
     config.add_index_field 'published_ssim', label: 'Published'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -206,6 +206,10 @@ module ApplicationHelper
     HTML
     html.html_safe
   end
+
+  def authors_search_results_helper(field)
+    field[:value].join("; ")
+  end
 end
 # rubocop:enable Rails/OutputSafety
 # rubocop:enable Metrics/ModuleLength

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -13,7 +13,7 @@ describe 'Search Results Page', type: :system, js: true do
     visit '/?search_field=all_fields&q='
 
     expect(page).to have_link('Midplane neutral density profiles in the National Spherical Torus Experiment', href: '/catalog/78348')
-    expect(page).to have_content 'Stotler, D., F. Scotti, R.E. Bell, A. Diallo' # authors
+    expect(page).to have_content 'Stotler, D.; F. Scotti; R.E. Bell; A. Diallo' # authors
     expect(page).to have_content 'Atomic and molecular density data in the outer midplane of NSTX' # abstract
   end
 


### PR DESCRIPTION
We updated the Show page to list authors separated by semi colons (PR #168) but we forgot to update the search results to do the same. This PR fixes that.

![authors_search_results](https://user-images.githubusercontent.com/568286/155179722-c4f0d70e-71bf-48f4-bc02-dc848da787e0.png)

