### PR TITLE
Show community and collection in the metadata

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -81,6 +81,14 @@ class SolrDocument
     fetch('creator_tesim', [])
   end
 
+  def community_path
+    fetch("community_path_name_ssi", "")
+  end
+
+  def collection_name
+    fetch("collection_name_ssi", "")
+  end
+
   def contributors
     fetch("contributor_tsim", [])
   end

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -11,6 +11,8 @@
             <%= render_field_row_many "Creator", @document.creators %>
             <%= render_field_row_many "Contributor", @document.contributors %>
             <%= render_field_row_search_link "Domain", @document.domain, "domain_ssi" %>
+            <%= render_field_row "Community", @document.community_path %>
+            <%= render_field_row "Collection", @document.collection_name %>
             <%= render_field_row "Date Accessioned", @document.accessioned_date, true %> <!-- displayed by default -->
             <%= render_field_row "Date Issued", @document.issued_date, true %> <!-- displayed by default -->
             <%= render_field_row "Date Created", @document.date_created %>

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -12,13 +12,20 @@ describe 'Single item page', type: :system, js: true do
     indexer.index
   end
 
+  # rubocop:disable Layout/ExampleLength
   it "has expected metadata" do
     visit '/catalog/78348'
     expect(page).to have_content "Midplane neutral density profiles in the National Spherical Torus Experiment"
 
     authors = "<span>Stotler, D.; F. Scotti; R.E. Bell; A. Diallo; B.P. LeBlanc; M. Podesta; A.L. Roquemore; P.W. Ross</span>"
-    expect(page.html.include?(authors)).to be true
+    community = "<span>Princeton Plasma Physics Laboratory|Spherical Torus</span>"
+    collection = "<span>NSTX</span>"
+    expected_values = [authors, community, collection]
+    expected_values.each do |value|
+      expect(page.html.include?(value)).to be true
+    end
   end
+  # rubocop:enable Layout/ExampleLength
 
   # rubocop:disable Layout/LineLength
   it "has expected citation information" do


### PR DESCRIPTION
Now that we are indexing and faceting the community and the collection (see PR #166) it makes sense to display these values in the Show page as well.

