### PR TITLE
Reorder fields in header

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -13,7 +13,7 @@
 }
 
 .issue-date-header {
-  font-size: 1.10rem;
+  font-size: 1.1rem;
   font-weight: 600;
   padding-top: 20px;
   padding-left: 15px;

--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -11,3 +11,11 @@
 .hidden-row {
   display: none;
 }
+
+.issue-date-header {
+  font-size: 1.10rem;
+  font-weight: 600;
+  padding-top: 20px;
+  padding-left: 15px;
+  padding-bottom: 20px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -210,6 +210,27 @@ module ApplicationHelper
   def authors_search_results_helper(field)
     field[:value].join("; ")
   end
+
+  def render_author(name, add_separator)
+    return if name.blank?
+
+    icon_html = '<i class="bi bi-person-fill"></i>'
+    separator = add_separator ? ";" : ""
+    name_html = "#{name}#{separator}"
+    if name == 'Koeser, Rebecca Sutton'
+      # Hard-coded for now to demo how researchers with ORCiD will display
+      icon_html = '<img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />'
+      name_html = '<a href="https://orcid.org/0000-0002-8762-8057" target="_blank">' + name + '</a>' + separator
+    end
+
+    html = <<-HTML
+    <span>
+      #{icon_html}
+      #{name_html}
+    </span>
+    HTML
+    html.html_safe
+  end
 end
 # rubocop:enable Rails/OutputSafety
 # rubocop:enable Metrics/ModuleLength

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -14,7 +14,7 @@
             <%= render_field_row "Community", @document.community_path %>
             <%= render_field_row "Collection", @document.collection_name %>
             <%= render_field_row "Date Accessioned", @document.accessioned_date, true %> <!-- displayed by default -->
-            <%= render_field_row "Date Issued", @document.issued_date, true %> <!-- displayed by default -->
+            <%= render_field_row "Issue date", @document.issued_date, true %> <!-- displayed by default -->
             <%= render_field_row "Date Created", @document.date_created %>
             <%= render_field_row "Date Modified", @document.date_modified %>
             <%= render_field_row "Date Submitted", @document.date_submitted %>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -18,19 +18,22 @@
       <h1 class="index_title document-title-heading col">
         <span itemprop="name"><%= @document.title %></span>
       </h1>
+      <div class="col-sm-9 authors-heading">
+        <% @document.authors.each_with_index do |author, ix| %>
+          <%= render_author(author, ix < (@document.authors.count-1)) %>
+        <% end %>
+      </div>
       <div class="index-document-functions col-sm-3 col-lg-2">
         <!-- TODO add bookmarks -->
       </div>
     </header>
 
     <div class="lux">
-      <dl>
-        <dt class="blacklight-issue_date_ssim col-md-3"></dt>
-        <dd class="col-md-12 blacklight-issue_date_ssim">
-          <div class="document-issued-date" value="January 2017"></div>
-        </dd>
-      </dl>
-
+      <% if @document.issued_date.present? %>
+        <div class="issue-date-heading">
+          Issue date: <%= @document.issued_date %>
+        </div>
+      <% end %>
       <dl>
         <% @document.abstracts.each do |abstract| %>
         <dt class="blacklight-abstract_tsim col-md-3"></dt>

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -12,6 +12,14 @@ describe 'Single item page', type: :system, js: true do
     indexer.index
   end
 
+  it "has expected header fiedlds" do
+    visit '/catalog/78348'
+    expect(page).to have_css '.document-title-heading'
+    expect(page).to have_css '.authors-heading'
+    expect(page).to have_css 'div.authors-heading > span > i.bi-person-fill'
+    expect(page).to have_css '.issue-date-heading'
+  end
+
   # rubocop:disable Layout/ExampleLength
   it "has expected metadata" do
     visit '/catalog/78348'


### PR DESCRIPTION
Reorders the fields shown at the top of the page as requested in #157.

I did a few things slightly different from the original request, like adding a gray person icon next to each name when they don't have an ORCID and hard-coded one particular researcher to show the ORCID icon and link to her profile so that stakeholders can get a better idea how this will work in practice.

I am also using a semicolon (rather than a comma) after each name so that we display them as everywhere else in the system. We could remove the semicolon if we keep the icons for everybody.

![fields_in_header](https://user-images.githubusercontent.com/568286/155408215-74cc9352-4e1b-4c27-9e68-d84291f33dca.png)

Closes #157 
