### PR TITLE
Track and show downloads via Plausible

### DIFF
--- a/app/assets/javascripts/plausible.js
+++ b/app/assets/javascripts/plausible.js
@@ -1,9 +1,9 @@
 function log_plausible_file_download(filename) {
   console.log("log_plausible_file_download: " + filename);
-  plausible("Download", { props: { info: filename } });
+  plausible("Download", { props: { filename: filename } });
 }
 
 function log_plausible_globus_download(id) {
   console.log("log_plausible_globus_download: " + id);
-  plausible("GlobusDownload", { props: { info: id } });
+  plausible("Download", { props: { filename: "globus-download" } });
 }

--- a/app/assets/javascripts/plausible.js
+++ b/app/assets/javascripts/plausible.js
@@ -1,3 +1,9 @@
-function log_plausible(component_name) {
-  plausible("Download", { props: { info: component_name } });
+function log_plausible_file_download(filename) {
+  console.log("log_plausible_file_download: " + filename);
+  plausible("Download", { props: { info: filename } });
+}
+
+function log_plausible_globus_download(id) {
+  console.log("log_plausible_globus_download: " + id);
+  plausible("GlobusDownload", { props: { info: id } });
 }

--- a/app/assets/javascripts/plausible.js
+++ b/app/assets/javascripts/plausible.js
@@ -1,9 +1,15 @@
+// Notice that we don't pass the document ID in our calls to Plausible
+// because Plausible automatically groups events by the current page
+// and we make these calls from the document Show page e.g. /catalog/:id
 function log_plausible_file_download(filename) {
   console.log("log_plausible_file_download: " + filename);
   plausible("Download", { props: { filename: filename } });
 }
 
 function log_plausible_globus_download(id) {
+  // Use a fake filename (globus-download) to track Globus downloads in the same property
+  // as file downloads. This is so that we can fetch all downloads with a single Plausible
+  // API call (see ./app/models/plausible.rb for more information)
   console.log("log_plausible_globus_download: " + id);
   plausible("Download", { props: { filename: "globus-download" } });
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -199,7 +199,7 @@ module ApplicationHelper
     html = <<-HTML
     <div id="globus">
       <button data-v-b7851b04="" type="button" class="document-downloads__button lux-button solid medium">
-        #{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer', class: 'globus-download-link', data: {item_id: item_id})}
+        #{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer', class: 'globus-download-link', data: { item_id: item_id })}
         <i class="bi bi-cloud-arrow-down-fill"></i>
       </button>
     </div>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -194,12 +194,12 @@ module ApplicationHelper
     html.html_safe
   end
 
-  def render_globus_download(uri)
-    return if uri.blank?
+  def render_globus_download(uri, item_id)
+    return if uri.nil?
     html = <<-HTML
     <div id="globus">
       <button data-v-b7851b04="" type="button" class="document-downloads__button lux-button solid medium">
-        #{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer')}
+        #{link_to('Download from Globus', uri, target: '_blank', title: 'opens in a new tab', rel: 'noopener noreferrer', class: 'globus-download-link', data: {item_id: item_id})}
         <i class="bi bi-cloud-arrow-down-fill"></i>
       </button>
     </div>

--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
-require 'plausible_api'
 module UsageHelper
   def downloads(files)
     files.map(&:downloads).inject(0, :+).to_s
-  end
-
-  def views
-    c = PlausibleApi::Client.new('pdc-discovery-staging.princeton.edu', (ENV['PLAUSIBLE_KEY'] || ''))
-    c.aggregate({ date: "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}", metrics: 'visitors,pageviews', filters: "event:page==/catalog/#{@document.id}" })["pageviews"]["value"]
-  rescue => e
-    logger.error "PLAUSIBLE ERROR: #{e.message}"
-    Honeybadger.notify(e.message)
-    '0'
   end
 end

--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -2,32 +2,48 @@
 require 'plausible_api'
 
 class Plausible
-  PLAUSIBLE_URL = 'https://plausible.io/api/v1'
+  PLAUSIBLE_API_URL = 'https://plausible.io/api/v1'
 
-  def self.page_views(document_id)
-    # byebug
-    # return 'X' unless Rails.env.staging? || Rails.env.production?
-    c = PlausibleApi::Client.new(Rails.configuration.pdc_discovery.plausible_site_id, (ENV['PLAUSIBLE_KEY'] || ''))
+  # Fetches pageview counts from Plausible for a given document id.
+  def self.pageviews(document_id)
+    return 'X' if ENV['PLAUSIBLE_KEY'].nil?
+
+    c = PlausibleApi::Client.new(Rails.configuration.pdc_discovery.plausible_site_id, ENV['PLAUSIBLE_KEY'])
     response = c.aggregate({ date: "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}", metrics: 'visitors,pageviews', filters: "event:page==/catalog/#{document_id}" })
     response["pageviews"]["value"]
   rescue => e
     Rails.logger.error "PLAUSIBLE ERROR: (Pageviews for document: #{document_id}) #{e.message}"
     Honeybadger.notify(e.message)
-    '0'
+    0
   end
 
+  # Fetches download counts from Plausible for a given document id.
+  #
+  # We store downloads by file name for each document id (page=/catalog/123). We also store downloads from
+  # Globus in a reserved filename ("globus-download") as part of this data.
+  #
+  # This method fetches the breakdown for all downloads by file name for a given document_id and aggregates them.
+  # We could provide stats by individual file and/or for specific time periods (e.g. period=6mo) in the future.
+  #
+  # Notice that this methods goes straight to the Plausible API (without using the PlausbleApi gem)
+  # because the gem does not support yet the ability to fetch this kind of information.
   def self.downloads(document_id)
+    return 'X' if ENV['PLAUSIBLE_KEY'].nil?
+
     site_id = Rails.configuration.pdc_discovery.plausible_site_id
-    period = "7d"
     page = "/catalog/#{document_id}"
-    url = "#{PLAUSIBLE_URL}/stats/breakdown?site_id=#{site_id}&period=#{period}&property=event:props:filename&filters=event:page==#{page}&metrics=visitors,pageviews"
+    url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=event:props:filename&filters=event:page==#{page}&metrics=visitors,pageviews"
     authorization = "Bearer #{ENV['PLAUSIBLE_KEY']}"
-    response = HTTParty.get(sub_community_url, headers: { 'Authorization' => authorization})
-    Rails.logger.info response.to_s
-    '123'
+    response = HTTParty.get(url, headers: { 'Authorization' => authorization })
+    total_downloads = 0
+    response["results"].each do |result|
+      next if result["filename"] == "(none)" # Skip old test data
+      total_downloads += result["visitors"]
+    end
+    total_downloads
   rescue => e
     Rails.logger.error "PLAUSIBLE ERROR: (Downloads for document: #{document_id}) #{e.message}"
     Honeybadger.notify(e.message)
-    '0'
+    0
   end
 end

--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'plausible_api'
+
+class Plausible
+  def self.page_views(document_id)
+    # byebug
+    # return 'X' unless Rails.env.staging? || Rails.env.production?
+
+    c = PlausibleApi::Client.new(Rails.configuration.pdc_discovery.plausible_site_id, (ENV['PLAUSIBLE_KEY'] || ''))
+    response = c.aggregate({ date: "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}", metrics: 'visitors,pageviews', filters: "event:page==/catalog/#{document_id}" })
+    response["pageviews"]["value"]
+  rescue => e
+    logger.error "PLAUSIBLE ERROR: (Document: #{document_id}) #{e.message}"
+    Honeybadger.notify(e.message)
+    '0'
+  end
+
+  def self.downloads(document_id)
+  end
+end

--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -2,19 +2,32 @@
 require 'plausible_api'
 
 class Plausible
+  PLAUSIBLE_URL = 'https://plausible.io/api/v1'
+
   def self.page_views(document_id)
     # byebug
     # return 'X' unless Rails.env.staging? || Rails.env.production?
-
     c = PlausibleApi::Client.new(Rails.configuration.pdc_discovery.plausible_site_id, (ENV['PLAUSIBLE_KEY'] || ''))
     response = c.aggregate({ date: "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}", metrics: 'visitors,pageviews', filters: "event:page==/catalog/#{document_id}" })
     response["pageviews"]["value"]
   rescue => e
-    logger.error "PLAUSIBLE ERROR: (Document: #{document_id}) #{e.message}"
+    Rails.logger.error "PLAUSIBLE ERROR: (Pageviews for document: #{document_id}) #{e.message}"
     Honeybadger.notify(e.message)
     '0'
   end
 
   def self.downloads(document_id)
+    site_id = Rails.configuration.pdc_discovery.plausible_site_id
+    period = "7d"
+    page = "/catalog/#{document_id}"
+    url = "#{PLAUSIBLE_URL}/stats/breakdown?site_id=#{site_id}&period=#{period}&property=event:props:filename&filters=event:page==#{page}&metrics=visitors,pageviews"
+    authorization = "Bearer #{ENV['PLAUSIBLE_KEY']}"
+    response = HTTParty.get(sub_community_url, headers: { 'Authorization' => authorization})
+    Rails.logger.info response.to_s
+    '123'
+  rescue => e
+    Rails.logger.error "PLAUSIBLE ERROR: (Downloads for document: #{document_id}) #{e.message}"
+    Honeybadger.notify(e.message)
+    '0'
   end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -172,6 +172,13 @@ class SolrDocument
     fetch("format_ssim", [])
   end
 
+  def globus_uri
+    uri.each do |link|
+      return link if link.downcase.start_with?('https://app.globus.org/')
+    end
+    nil
+  end
+
   def extent
     fetch("extent_ssim", [])
   end

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -34,9 +34,7 @@
           </tbody>
           <tfoot></tfoot>
         </table>
-        <% @document.uri.each do |uri| %>
-          <%= render_globus_download(uri) if uri.include?("app.globus.org") %>
-        <% end %>
+        <%= render_globus_download(@document.globus_uri, @document.id) %>
       </div>
     </div>
   </div>
@@ -48,12 +46,18 @@ $(function() {
   // Wire DataTable for the file list.
   $('#files-table').DataTable();
 
-  // Track via Plausible file downloads.
+  // Track file downloads via Plausible.
   $(".documents-file-link").click(function() {
     var filename = $(this).text();
-    log_plausible(filename);
+    log_plausible_file_download(filename);
     return true;
   });
 
+  // Track Globus downloads via Plausible.
+  $(".globus-download-link").click(function() {
+    var id = $(this).data('item-id');
+    log_plausible_globus_download(id);
+    return true;
+  });
 });
 </script>

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -19,7 +19,7 @@
                 </th>
                 <td>
                   <span>
-                    <i class="bi bi-file-arrow-down-fill"></i>
+                    <i class="bi bi-file-arrow-down"></i>
                     <a href="<%= file.download_url %>" class="documents-file-link" target="_blank" title="<%= file.name %>"><%= truncate(file.name, length: 60) %></a>
                   </span>
                 </td>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="sidebar-usage" class="sidebar">
   <ul>
-    <li><span class="number"><%= Plausible.pageviews(@document.id) %> </span> <i class="bi bi-eye-fill"></i>views</li>
-    <li><span class="number"><%= Plausible.downloads(@document.id) %> </span> <i class="bi bi-file-arrow-down"></i>downloads</li>
+    <li><span id="pageviews" class="number"><%= Plausible.pageviews(@document.id) %> </span> <i class="bi bi-eye-fill"></i>views</li>
+    <li><span id="downloads" class="number"><%= Plausible.downloads(@document.id) %> </span> <i class="bi bi-file-arrow-down"></i>downloads</li>
   </ul>
 </div>
 

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,6 +1,6 @@
 <div id="sidebar-usage" class="sidebar">
   <ul>
-    <li><span class="number"><%= Rails.env.staging? || Rails.env.production? ? views : 'X' %> </span> <i class="bi bi-eye-fill"></i>views</li>
+    <li><span class="number"><%= Plausible.page_views(@document.id) %> </span> <i class="bi bi-eye-fill"></i>views</li>
   </ul>
 </div>
 

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -1,6 +1,7 @@
 <div id="sidebar-usage" class="sidebar">
   <ul>
-    <li><span class="number"><%= Plausible.page_views(@document.id) %> </span> <i class="bi bi-eye-fill"></i>views</li>
+    <li><span class="number"><%= Plausible.pageviews(@document.id) %> </span> <i class="bi bi-eye-fill"></i>views</li>
+    <li><span class="number"><%= Plausible.downloads(@document.id) %> </span> <i class="bi bi-file-arrow-down"></i>downloads</li>
   </ul>
 </div>
 

--- a/config/pdc_discovery.yml
+++ b/config/pdc_discovery.yml
@@ -1,5 +1,6 @@
 default: &default
   dataspace_url: <%= ENV["DATASPACE_URL"] || "https://dataspace-dev.princeton.edu" %>
+  plausible_site_id: <%= "pdc-discovery-staging.princeton.edu" %>
 
 development:
   <<: *default
@@ -7,9 +8,12 @@ development:
 test:
   <<: *default
 
+# TODO: switch plausible_site_id to production id once we create one in Plausible
 production:
   <<: *default
   dataspace_url: <%= ENV["DATASPACE_URL"] %>
+  plausible_site_id: <%= "pdc-discovery-staging.princeton.edu" %>
 
 staging:
   <<: *default
+  plausible_site_id: <%= "pdc-discovery-staging.princeton.edu" %>

--- a/spec/fixtures/files/plausible_breakdown_catalog_88163.json
+++ b/spec/fixtures/files/plausible_breakdown_catalog_88163.json
@@ -1,0 +1,19 @@
+{
+    "results": [
+        {
+            "filename": "(none)",
+            "pageviews": 39,
+            "visitors": 16
+        },
+        {
+            "filename": "globus-download",
+            "pageviews": 0,
+            "visitors": 4
+        },
+        {
+            "filename": "Corr_MVPA_archive.tar.gz",
+            "pageviews": 0,
+            "visitors": 2
+        }
+    ]
+}

--- a/spec/models/plausible_spec.rb
+++ b/spec/models/plausible_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 # rubocop:disable Layout/LineLength
 RSpec.describe Plausible do
   before do
-
     stub_request(:get, "https://plausible.io/api/v1/stats/breakdown?filters=event:page==/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu")
       .with(
         headers: {

--- a/spec/models/plausible_spec.rb
+++ b/spec/models/plausible_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 # rubocop:disable Layout/LineLength
 RSpec.describe Plausible do
   before do
-    ENV['PLAUSIBLE_KEY'] = 'no-key-for-testing'
 
     stub_request(:get, "https://plausible.io/api/v1/stats/breakdown?filters=event:page==/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu")
       .with(
@@ -25,7 +24,9 @@ RSpec.describe Plausible do
 
   describe "#downloads" do
     it "rolls up downloads" do
+      ENV['PLAUSIBLE_KEY'] = 'no-key-for-testing'
       expect(described_class.downloads('88163')).to eq 6
+      ENV['PLAUSIBLE_KEY'] = nil
     end
   end
 end

--- a/spec/models/plausible_spec.rb
+++ b/spec/models/plausible_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable Layout/LineLength
+RSpec.describe Plausible do
+  before do
+    ENV['PLAUSIBLE_KEY'] = 'no-key-for-testing'
+
+    stub_request(:get, "https://plausible.io/api/v1/stats/breakdown?filters=event:page==/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu")
+      .with(
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization' => 'Bearer no-key-for-testing',
+          'User-Agent' => 'Ruby'
+        }
+      )
+      .to_return(
+        status: 200,
+        body: file_fixture("plausible_breakdown_catalog_88163.json"),
+        headers: { 'content-type' => 'application/json; charset=utf-8' }
+      )
+  end
+
+  describe "#downloads" do
+    it "rolls up downloads" do
+      expect(described_class.downloads('88163')).to eq 6
+    end
+  end
+end
+# rubocop:enable Layout/LineLength

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -48,4 +48,10 @@ describe 'Single item page', type: :system, js: true do
     visit '/catalog/78348'
     expect(page.html.include?('<span class="Z3988"')).to be true
   end
+
+  it "renders pageviews and downloads stats" do
+    visit '/catalog/78348'
+    expect(page.html.include?('<span id="pageviews"')).to be true
+    expect(page.html.include?('<span id="downloads"')).to be true
+  end
 end


### PR DESCRIPTION
Adds support to track Globus Downloads via Plausible and displays the total number of downloads (file downloads + Globus downloads) on the Show page:

![downloads](https://user-images.githubusercontent.com/568286/156233382-4d827e31-30e9-4dfe-8c77-5d911dca3781.png)

Notice that we are using the PlausibleAPI gem to fetch **pageviews** but we are going straight to Plausible API (without the gem) to fetch **download** information since this kind of information is not yet supported in the gem. I moved all the "Plausible" code to its own class under `./app/models/plausible.rb` and we can refactor the downloads code to use the gem once the gem has been updated.
 
Fixes #146 
Fixes #133
