### PR TITLE
Align element in the Show page

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -19,3 +19,20 @@
   padding-left: 15px;
   padding-bottom: 20px;
 }
+
+.index_title {
+  padding-left: 0px;
+  padding-right: 0px;
+}
+
+.issue-date-heading {
+  padding-left: 0px;
+}
+
+.abstract-container {
+  padding-left: 0px;
+}
+
+.description-container {
+  padding-left: 0px;
+}

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -15,16 +15,13 @@
 <div id="document" data-document-id="<%= @document.id %>" itemscope="itemscope" itemtype="http://schema.org/Thing" class="document">
   <div class="document-main-section">
     <header class="documentHeader row">
-      <h1 class="index_title document-title-heading col">
-        <span itemprop="name"><%= @document.title %></span>
-      </h1>
-      <div class="col-sm-9 authors-heading">
+      <div class="col-sm-12 authors-heading">
+        <h1 class="index_title document-title-heading col">
+          <span itemprop="name"><%= @document.title %></span>
+        </h1>
         <% @document.authors.each_with_index do |author, ix| %>
           <%= render_author(author, ix < (@document.authors.count-1)) %>
         <% end %>
-      </div>
-      <div class="index-document-functions col-sm-3 col-lg-2">
-        <!-- TODO add bookmarks -->
       </div>
     </header>
 
@@ -37,7 +34,7 @@
       <dl>
         <% @document.abstracts.each do |abstract| %>
         <dt class="blacklight-abstract_tsim col-md-3"></dt>
-        <dd class="col-md-12">
+        <dd class="col-md-12 abstract-container">
           <div class="document-abstract">
             <header>Abstract:</header>
             <p id="document-abstract-text" class="truncate-line-clamp"><%= abstract %></p>
@@ -50,7 +47,7 @@
       <dl>
         <% @document.descriptions.each do |description| %>
         <dt class="blacklight-description_tsim col-md-3"></dt>
-        <dd class="col-md-12 blacklight-description_tsim">
+        <dd class="col-md-12 description-container">
           <div class="document-description">
             <header>Description:</header>
             <p id="document-description-text" class="truncate-line-clamp"><%= description %></p>


### PR DESCRIPTION
Fixes alignment of elements in the show page and allows the title to take a larger horizontal space so that it does not wrap unnecessarily. 

Fixes #179

## Before
![before](https://user-images.githubusercontent.com/568286/156396937-050748db-f256-4e1c-89bf-60f498c3df2c.png)
 
## After
![after](https://user-images.githubusercontent.com/568286/156396987-a017c799-fb0a-4270-abb7-4652760458ce.png)

