### PR TITLE
Do not lose logs on redeploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,6 +4,8 @@ lock "~> 3.16.0"
 set :application, "pdc_discovery"
 set :repo_url, "https://github.com/pulibrary/pdc_discovery.git"
 
+set :linked_dirs, %w(log public/system public/assets)
+
 # Default branch is :main
 set :branch, ENV["BRANCH"] || "main"
 


### PR DESCRIPTION
This PR turns `logs`, `public/system`, and `public/assets` into symlinks from the `shared` directory, so they are not lost when a new version of the software is deployed. 