### PR TITLE
148 logo display

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,12 +1,15 @@
 #footer {
-  padding: 40px 0px 20px 0px;
-  background-color: #000000;
-  color: #ffffff;
+  background-color: #cecece;
+  color: #000000;
   font-size: 11px;
   text-align: right;
+  position: fixed;
+  padding: 30px 0px 10px 0px;
+  bottom: 0;
+  width: 100%;
   .content {
     display: inline-block;
-    background-color: #ffffff;
+    background-color: #FFFFFF;
     width: 100%;
     height: auto;
     margin: 0 auto;

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -6,7 +6,7 @@
   text-align: right;
   .content {
     display: inline-block;
-    background-color: #FFFFFF;
+    background-color: #ffffff;
     width: 100%;
     height: auto;
     margin: 0 auto;

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,12 +1,9 @@
 #footer {
+  padding: 40px 0px 20px 0px;
   background-color: #cecece;
   color: #000000;
   font-size: 11px;
   text-align: right;
-  position: fixed;
-  padding: 30px 0px 10px 0px;
-  bottom: 0;
-  width: 100%;
   .content {
     display: inline-block;
     background-color: #FFFFFF;

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,8 +1,9 @@
 .navbar-logo {
   background-image: asset_url("logo.svg");
-  background-size: cover;
-  height: 7em;
-  width: 10em;
+  display: inline-block;
+  flex: 0 0 350px;
+  height: 100px;
+  width: 350px;
 }
 
 .navbar.bg-light {
@@ -21,6 +22,15 @@
 .submit-search-text {
   background-color: #005bbd;
   color: #ffffff;
+}
+
+.nav-links-search {
+  width: 100%;
+}
+
+.navbar-nav {
+  float: left;
+  padding: 5px 5px 5px 10px;
 }
 
 .navbar-nav .nav-item {

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,5 +1,8 @@
 .navbar-logo {
   background-image: asset_url("logo.svg");
+  background-size: cover;
+  height: 7em;
+  width: 10em;
 }
 
 .navbar.bg-light {
@@ -18,4 +21,8 @@
 .submit-search-text {
   background-color: #005bbd;
   color: #ffffff;
+}
+
+.navbar-nav .nav-item {
+  clear: both;
 }

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -5,16 +5,15 @@
       <span class="navbar-toggler-icon"></span>
     </button>
 
-    <div class="collapse navbar-collapse justify-content-md-start" id="user-util-collapse">
+    <div class="nav-links-search">
       <%= render 'shared/nav_links' %>
+      <% unless current_page?('/') && params[:search_field].blank? && params[:q].blank? %>
+        <%= content_tag :div, class: 'navbar-search', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
+          <div class="<%= container_classes %>">
+            <%= render_search_bar  %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </nav>
-
-<% unless current_page?('/') && params[:search_field].blank? && params[:q].blank? %>
-  <%= content_tag :div, class: 'navbar-search navbar navbar-light bg-light', role: 'navigation', aria: { label: t('blacklight.search.header') } do %>
-    <div class="<%= container_classes %>">
-      <%= render_search_bar  %>
-    </div>
-  <% end %>
-<% end %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-md navbar-light bg-light topbar" role="navigation">
+<nav class="navbar navbar-expand-lg navbar-light bg-light topbar" role="navigation">
   <div class="<%= container_classes %>">
     <%= link_to application_name, root_path, class: 'mb-0 navbar-brand navbar-logo' %>
     <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-bs-toggle="collapse" data-target="#user-util-collapse" data-bs-target="#user-util-collapse" aria-controls="user-util-collapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/spec/system/single_item_metadata_spec.rb
+++ b/spec/system/single_item_metadata_spec.rb
@@ -20,7 +20,7 @@ describe 'Single item page', type: :system, js: true do
     expect(page).to have_css '.issue-date-heading'
   end
 
-  # rubocop:disable Layout/ExampleLength
+  # rubocop:disable RSpec/ExampleLength
   it "has expected metadata" do
     visit '/catalog/78348'
     expect(page).to have_content "Midplane neutral density profiles in the National Spherical Torus Experiment"
@@ -33,7 +33,7 @@ describe 'Single item page', type: :system, js: true do
       expect(page.html.include?(value)).to be true
     end
   end
-  # rubocop:enable Layout/ExampleLength
+  # rubocop:enable RSpec/ExampleLength
 
   # rubocop:disable Layout/LineLength
   it "has expected citation information" do


### PR DESCRIPTION
Closes #148 

This also has a couple of minor tweaks to the footer display.

## Screenshots:

### Search results:
![Screen Shot 2022-03-03 at 1 33 28 PM](https://user-images.githubusercontent.com/7795797/156630546-fc5dca73-dcd1-4068-a9d2-8ffd55655cd3.png)

### Single item:
![Screen Shot 2022-03-03 at 1 33 38 PM](https://user-images.githubusercontent.com/7795797/156630501-a9f3c82e-e160-443f-8c8e-3bf05d0b51a7.png)

### Homepage: 
![Screen Shot 2022-03-03 at 1 33 33 PM](https://user-images.githubusercontent.com/7795797/156630525-27c4fb75-9bdc-423a-992f-7f0fd0325792.png)


