### PR TITLE
Ignore license.txt when importing from DataSpace

### DIFF
--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -403,6 +403,10 @@ to_field 'files_ss' do |record, accumulator, _context|
       handle: dataspace_handle
     }
   end
+
+  # Exclude DSpace license.txt file
+  bitstreams.reject! { |bitstream| bitstream[:name] == "license.txt" }
+
   accumulator.concat [bitstreams.to_json.to_s]
 end
 

--- a/spec/fixtures/astrophysical_sciences.xml
+++ b/spec/fixtures/astrophysical_sciences.xml
@@ -21,6 +21,22 @@
       <sequenceId>1</sequenceId>
       <sizeBytes>3733863</sizeBytes>
     </bitstreams>
+    <bitstreams>
+      <expand>parent</expand>
+      <expand>policies</expand>
+      <expand>all</expand>
+      <id>20123</id>
+      <name>license.txt</name>
+      <type>bitstream</type>
+      <bundleName>TEXT</bundleName>
+      <checkSum checkSumAlgorithm="MD5">e1cccfa7825760e9cc707e039610d97d</checkSum>
+      <description>DSpace defaultlicense file</description>
+      <format>Text</format>
+      <mimeType>text/plain</mimeType>
+      <retrieveLink>/bitstreams/20123/retrieve</retrieveLink>
+      <sequenceId>2</sequenceId>
+      <sizeBytes>313121</sizeBytes>
+    </bitstreams>
     <lastModified>2012-09-25 10:11:20.502</lastModified>
     <metadata>
       <key>dc.contributor.advisor</key>

--- a/spec/system/research_data_indexing_spec.rb
+++ b/spec/system/research_data_indexing_spec.rb
@@ -35,7 +35,9 @@ describe 'DataSpace research data indexing', type: :system do
   end
 
   it 'files' do
+    # The fixture has two files but we expect the "license.txt" to be ignored
     files = JSON.parse(result['files_ss'].first)
+    expect(files.count).to eq 1
     expect(files.first["name"]).to eq 'Lee_princeton_0181D_10086.pdf'
   end
 end


### PR DESCRIPTION
Fixes #203