### PR TITLE
Citation font

### DIFF
--- a/app/assets/stylesheets/modules/methods.scss
+++ b/app/assets/stylesheets/modules/methods.scss
@@ -31,10 +31,18 @@
 }
 
 .apa-citation {
-  font-family: "Courier New", Courier, monospace;
+  font-family: inherit;
 }
 
 .bibtex-citation {
   font-family: "Courier New", Courier, monospace;
   background-color: #f5f5f5; /* light gray */
+}
+
+.apa-citation-courier {
+  font-family: "Courier New", Courier, monospace;
+}
+
+.apa-citation-zenodo {
+  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }

--- a/app/assets/stylesheets/modules/methods.scss
+++ b/app/assets/stylesheets/modules/methods.scss
@@ -31,18 +31,10 @@
 }
 
 .apa-citation {
-  font-family: inherit;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
 .bibtex-citation {
-  font-family: "Courier New", Courier, monospace;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   background-color: #f5f5f5; /* light gray */
-}
-
-.apa-citation-courier {
-  font-family: "Courier New", Courier, monospace;
-}
-
-.apa-citation-zenodo {
-  font-family: Menlo,Monaco,Consolas,"Courier New",monospace;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,9 +137,18 @@ module ApplicationHelper
     bibtex_html = html_escape(bibtex).gsub("\r\n", "<br/>").gsub("\t", "  ").gsub("  ", "&nbsp;&nbsp;")
     bibtex_text = html_escape(bibtex).gsub("\t", "  ")
 
+    css_suffix = case params["style"]
+    when "zenodo"
+      "-zenodo"
+    when "courier"
+      "-courier"
+    else
+      ""
+    end
+
     html = <<-HTML
       <div class="citation-apa-container">
-        <div class="apa-citation">#{html_escape(apa)}</div>
+        <div class="apa-citation#{css_suffix}">#{html_escape(apa)}</div>
         <button id="copy-apa-citation-button" class="copy-citation-button btn btn-sm" data-style="APA" data-text="#{html_escape(apa)}" title="Copy citation to the clipboard">
           <i class="bi bi-clipboard" title="Copy citation to the clipboard"></i>
           <span class="copy-citation-label-normal">COPY</span>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,18 +137,9 @@ module ApplicationHelper
     bibtex_html = html_escape(bibtex).gsub("\r\n", "<br/>").gsub("\t", "  ").gsub("  ", "&nbsp;&nbsp;")
     bibtex_text = html_escape(bibtex).gsub("\t", "  ")
 
-    css_suffix = case params["style"]
-    when "zenodo"
-      "-zenodo"
-    when "courier"
-      "-courier"
-    else
-      ""
-    end
-
     html = <<-HTML
       <div class="citation-apa-container">
-        <div class="apa-citation#{css_suffix}">#{html_escape(apa)}</div>
+        <div class="apa-citation">#{html_escape(apa)}</div>
         <button id="copy-apa-citation-button" class="copy-citation-button btn btn-sm" data-style="APA" data-text="#{html_escape(apa)}" title="Copy citation to the clipboard">
           <i class="bi bi-clipboard" title="Copy citation to the clipboard"></i>
           <span class="copy-citation-label-normal">COPY</span>


### PR DESCRIPTION
Switched the font used to display citation based on feedback from the folks at PRDS. The new font is the same used by Zenodo and it stands out without being hard to read.

![Screen Shot 2022-03-10 at 12 06 00 PM](https://user-images.githubusercontent.com/568286/157716647-b3ea90c4-d899-4050-84e5-574031bfabb3.png)

![Screen Shot 2022-03-10 at 12 06 07 PM](https://user-images.githubusercontent.com/568286/157716700-e8bddb96-f65c-408b-a32c-690492a14510.png)

