### PR TITLE
Styling changes

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -6,16 +6,16 @@
     }
 </style>
 
-<h1>About Princeton's Research Data Repository</h1>
+<h2>About Princeton's Research Data Repository</h2>
 <p>Our multi-disciplinary digital repository offers expert curation services and is designed to archive and publicly
     disseminate data and code that are the result of research activities by Princeton University's research community. </p>
 
-<h2>What's new?</h2>
+<h3>What's new?</h3>
 <p>The Princeton research data repository has a new front-end, called Princeton Data Commons: Discovery. This is an early
     release of our evolving discovery layer, and we are welcoming feedback from everyone. Please email us at
     <a href="mailto:prds@princeton.edu">prds@princeton.edu</a> with any questions or comments.</p>
 
-<h2>Why does Princeton University have an online data repository?</h2>
+<h3>Why does Princeton University have an online data repository?</h3>
 <p>Princeton University is committed to supporting research that has the potential to benefit humanity at large.
     Very often, research conducted by members of the Princeton community is publicly funded and therefore entails
     an explicit responsibility to share the products of the research openly with taxpayers. Some academic journals
@@ -26,13 +26,13 @@
     repository exists to support long-term archiving and open dissemination of any digital research product from
     the Princeton community, meeting funder and publisher policies, as well as open research principles.<p>
 
-<h2>Who has access to items in the repository?</h2>
+<h3>Who has access to items in the repository?</h3>
 <p>Anyone can browse, download, and investigate the items, free of charge. Many, if not most, of these items have an
     intended audience of specialists in a given field of research, and users should be cautioned that individual
     contributors typically retain copyrights to their research works, so permissions may be required for some forms
     of use and re-use, depending on the item.</p>
 
-<h2>Who manages Princeton's Research Data Repository?</h2>
+<h3>Who manages Princeton's Research Data Repository?</h3>
 <p>Data are curated and published by the <a href="https://researchdata.princeton.edu/">Princeton Research Data Service</a>
     (PRDS), with technical and infrastructure support from information technology staff at the Princeton University Library.
     PRDS curators review submissions with an eye toward discoverability, reusability, and long-term preservation - without
@@ -41,7 +41,7 @@
     <p>For general questions related to the repository, please contact the
         <a href="mailto:dspadmin@princeton.edu">curators</a>.</p>
 
-<h2>The Repository Team</h2>
+<h3>The Repository Team</h3>
 
     <p class="team-section">Development</p>
     <p>Hector Correa, James Griffin III, Kate Lynch, Bess Sadler</p>
@@ -58,7 +58,7 @@
     <p class="team-section">Director</p>
     <p>Wind Cowles</p>
 
-<h2>About the Princeton Data Commons (PDC) project</h2>
+<h3>About the Princeton Data Commons (PDC) project</h3>
 <p>The Princeton Data Commons is a project to create an ecosystem of online resources and tools to support and advance
     storing, preserving, managing, sharing, and curating digital research data. Princeton Data Commons - Discovery
     is the first application in this new ecosystem. For more information about the PDC project, please contact Wind

--- a/app/views/home/submit.html.erb
+++ b/app/views/home/submit.html.erb
@@ -1,26 +1,33 @@
-<h2>How to Submit to Princeton’s Research Data Repository</h2>
+<style>
+  .first-section {
+    padding-top: 6px;
+  }
+</style>
 
-<h3>Who can submit to DataSpace?</h3>
-<p>All faculty, staff, students, and affiliates of Princeton University are welcome to submit their digital research products to Princeton’s Research Data Repository.</p>
+<h2>How to Submit to Princeton's Research Data Repository</h2>
+
+<h3 class="first-section">Who can submit to DataSpace?</h3>
+<p>All faculty, staff, students, and affiliates of Princeton University are welcome to submit their digital research
+products to Princeton's Research Data Repository.</p>
 
 <h3>Steps to get started</h3>
 <ol>
   <li>
-    Sign into the repository to establish a username and password for the first time. 
-    To do this, navigate to <a href="https://dataspace.princeton.edu">https://dataspace.princeton.edu</a> 
+    Sign in to the repository to establish a username and password for the first time.
+    To do this, navigate to <a href="https://dataspace.princeton.edu">https://dataspace.princeton.edu</a>
     and log in with your University ID (NetID).
   </li>
 
   <li>
-    Then fill out this quick <%= link_to 'setup questionnaire', 'https://forms.gle/Agif28rNqGjQyacu7' %>. 
-    This allows the data curators to prepare for your particular needs. Depending on the size and complexity of your data, 
+    Then fill out this quick <%= link_to 'setup questionnaire', 'https://forms.gle/Agif28rNqGjQyacu7' %>.
+    This allows the data curators to prepare for your particular needs. Depending on the size and complexity of your data,
     your submission can usually be processed in a matter of days.
   </li>
 </ol>
 <p>For detailed information on the process, see the pages
-  <%= link_to 'Getting Started as a DataSpace Contributor', 'https://researchdata.princeton.edu/research-lifecycle-guide/getting-started-dataspace-contributor' %> 
+  <%= link_to 'Getting Started as a DataSpace Contributor', 'https://researchdata.princeton.edu/research-lifecycle-guide/getting-started-dataspace-contributor' %>
   and <%= link_to 'DataSpace Help', 'https://researchdata.princeton.edu/research-lifecycle-guide/dataspace-help' %>.
 </p>
- 
-If you have any questions, please contact the DataSpace curators at <%= mail_to 'dspadmin@princeton.edu' %> or you can set up a data submission consultation with the 
-<%= link_to 'Princeton Research Data Service', 'https://researchdata.princeton.edu/' %>. 
+
+If you have any questions, please contact the DataSpace curators at <%= mail_to 'dspadmin@princeton.edu' %> or you can set up a data submission consultation with the
+<%= link_to 'Princeton Research Data Service', 'https://researchdata.princeton.edu/' %>.


### PR DESCRIPTION
Adds a little bit of spacing between the title of the page and the first header and fixes a grammatical error in the **How to Submit** page. Makes the **About** page use the same heading sizes as the How to Submit page.

![Screen Shot 2022-03-10 at 2 39 02 PM](https://user-images.githubusercontent.com/568286/157742403-d39a8c90-23ed-4545-a3d2-a09b31a52e79.png)

![Screen Shot 2022-03-10 at 2 44 20 PM](https://user-images.githubusercontent.com/568286/157742449-76264f76-8fad-4869-965e-19b88230f854.png)

