### PR TITLE
Allows keyword searches to work again (while keeping the facet hidden)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,6 +98,10 @@ class CatalogController < ApplicationController
     config.add_facet_field 'genre_ssim', label: 'Type'
     config.add_facet_field 'year_available_itsi', label: 'Year Published', range: true
 
+    # Notice that is facet is not shown. Yet facet searches by this field do work
+    # and we use them when users click on the "Keywords" links in the Show page.
+    config.add_facet_field 'subject_all_ssim', label: 'Keywords', show: false
+
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.

--- a/spec/system/search_results_page_spec.rb
+++ b/spec/system/search_results_page_spec.rb
@@ -70,5 +70,11 @@ describe 'Search Results Page', type: :system, js: true do
       collection_facet_html = '<div class="card facet-limit blacklight-collection_name_ssi ">'
       expect(page.html.include?(collection_facet_html)).to be true
     end
+
+    it "searches by the keyword facet even thought it is a hidden facet" do
+      visit '/?f%5Bsubject_all_ssim%5D%5B%5D=Monte-Carlo+simulation'
+      expect(page.html.include?("Keywords")).to be true
+      expect(page.html.include?("Monte-Carlo simulation")).to be true
+    end
   end
 end


### PR DESCRIPTION
Fixes #245

