### PR TITLE
Removed blue gradient visible in Safari

### DIFF
--- a/app/assets/stylesheets/components/homepage.scss
+++ b/app/assets/stylesheets/components/homepage.scss
@@ -3,7 +3,7 @@
   background: linear-gradient(
       90deg,
       rgba(255, 255, 255, 1) 15%,
-      rgba(0, 212, 255, 0) 100%
+      rgba(255, 255, 255, 0) 100%
     ),
     asset_url("nodes-bg.svg") no-repeat center right;
   background-size: cover;


### PR DESCRIPTION
Closes #243 

## Before (in Safari):
![Screen Shot 2022-03-22 at 11 09 02 AM](https://user-images.githubusercontent.com/7795797/159514294-fb299e15-426c-4770-8de5-5c8b73336c6b.png)

## After (in Safari):  
![Screen Shot 2022-03-22 at 11 08 17 AM](https://user-images.githubusercontent.com/7795797/159514317-c1b8e36f-11dc-4ef3-9887-d75445762634.png)

