### PR TITLE
Add sitemap.xml to robots.txt

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,9 +24,8 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # Serve files in the public folder (so that we can serve robots.txt)
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+# https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap
+Sitemap: https://datacommons.princeton.edu/discovery/sitemap.xml


### PR DESCRIPTION
Allow Rails to serve our `robots.txt` file and update the `robots.txt` to include a reference to our shinny dynamically generated `sitemap.xml`

Part of #123 
