### PR TITLE
Fixes start up error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ group :development do
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'spring'
   gem 'web-console', '>= 4.1.0'
-  gem 'xray-rails', git: 'https://github.com/TylerRick/xray-rails.git', branch: 'add_nonce'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/TylerRick/xray-rails.git
-  revision: 63c02104f9eedfa81cb2f5189885b3ae36bd1cfb
-  branch: add_nonce
-  specs:
-    xray-rails (0.3.2)
-      rails (>= 3.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -574,7 +566,6 @@ DEPENDENCIES
   webmock
   webpacker (~> 5.0)
   whenever
-  xray-rails!
 
 RUBY VERSION
    ruby 3.0.3p157


### PR DESCRIPTION
Removes `xray-rails` gem from development environment since it causes a start up error with Ruby 3. It's not clear to me that we are in fact using that gem so I took the quick route and removed it.

Fixes #267 