### PR TITLE
Pinning Capistrano to 3.16 releases

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Load DSL and set up stages
 require "capistrano/setup"
 

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ end
 
 group :development do
   gem "bcrypt_pbkdf"
-  gem "capistrano", "~> 3.10", require: false
+  gem "capistrano", "3.16", "< 3.17", require: false
   gem "capistrano-passenger", require: false
   gem "capistrano-rails", "~> 1.4", require: false
   gem "ed25519"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.1.3)
-    capistrano (3.17.0)
+    capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -524,7 +524,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   bootstrap (~> 4.0)
   byebug
-  capistrano (~> 3.10)
+  capistrano (= 3.16, < 3.17)
   capistrano-passenger
   capistrano-rails (~> 1.4)
   capybara (>= 3.26)
@@ -571,4 +571,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.11
+   2.3.8

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.17.0"
+lock "~> 3.16.0"
 
 set :application, "pdc_discovery"
 set :repo_url, "https://github.com/pulibrary/pdc_discovery.git"


### PR DESCRIPTION
This was necessary given that deployments were failing with the following errors for `staging`:

```bash
From https://github.com/pulibrary/pdc_discovery
   d62dc8a..928c4fe  main       -> origin/main
 * [new tag]         v1.0.6     -> v1.0.6
(Backtrace restricted to imported tasks)
cap aborted!
Capfile locked at ~> 3.17.0, but 3.16.0 is loaded

Tasks: TOP => staging
(See full trace by running task with --trace)
```