### PR TITLE
Ensuring that the spec/requests/catalog_spec.rb test suite consistently passes

### DIFF
--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -2,6 +2,14 @@
 require 'rails_helper'
 
 RSpec.describe "Catalog", type: :request do
+  let(:dspace_fixtures) { File.read(File.join(fixture_path, 'spherical_torus.xml')) }
+  let(:indexer) do
+    DspaceIndexer.new(dspace_fixtures)
+  end
+  before do
+    indexer.index
+  end
+
   describe "GET /doi/:doi" do
     let(:doi) { "doi:10.1088/0029-5515/57/1/016034" }
     let(:document_id) { "84912" }


### PR DESCRIPTION
The test suite for `spec/requests/catalog_spec.rb` was experiencing intermittent failures on `circleci` and for local development environments.