### PR TITLE
Do not raise an exception when we try to delete index in production

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -28,10 +28,12 @@ namespace :index do
 
   desc 'Remove all indexed Documents from Solr'
   task delete: :environment do
-    raise("Deleting indices in Solr is unsupported for the environment #{Rails.env}") if Rails.env.production?
-
-    Blacklight.default_index.connection.delete_by_query('*:*')
-    Blacklight.default_index.connection.commit
+    if Rails.env.production?
+      Rails.logger.warn("Deleting indices in Solr is unsupported for the environment #{Rails.env}")
+    else
+      Blacklight.default_index.connection.delete_by_query('*:*')
+      Blacklight.default_index.connection.commit
+    end
   end
 
   desc 'Fetches the most recent community information from DataSpace and saves it to a file.'


### PR DESCRIPTION
Just log the error and continue.
At some point we'll need to make a more solid plan for how to re-index in production.