### PR TITLE
Indexing PDC Describe records

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -275,6 +275,15 @@ class SolrDocument
     fetch("rights_uri_ssim", [])
   end
 
+  # For PDC Describe records we have a single value for the name and the uri
+  # and we can safely assume they are related.
+  def rights_name_and_uri
+    name = fetch("rights_name_ssi", nil)
+    uri = fetch("rights_uri_ssi", nil)
+    return nil if name.nil? or uri.nil?
+    { name: name, uri: uri }
+  end
+
   def rights_holder
     fetch("rights_holder_ssim", [])
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -280,7 +280,7 @@ class SolrDocument
   def rights_name_and_uri
     name = fetch("rights_name_ssi", nil)
     uri = fetch("rights_uri_ssi", nil)
-    return nil if name.nil? or uri.nil?
+    return nil if name.nil? || uri.nil?
     { name: name, uri: uri }
   end
 

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -100,7 +100,11 @@
               <%= render_field_row "Relation URI", relation_uri %>
             <% end %>
 
-            <% if @document.rights_name_and_uri.nil? %>
+            <% if @document.rights_name_and_uri.present? %>
+              <!-- PDC Describe records have a single rights (name + uri) -->
+              <%= render_field_row "Rights", @document.rights_name_and_uri[:name] %>
+              <%= render_field_row_link "Rights URI", @document.rights_name_and_uri[:uri] %>
+            <% else %>
               <!-- DSpace records have two unrelated fields -->
               <% @document.rights.each do |rights| %>
                 <%= render_field_row "Rights", rights %>
@@ -108,10 +112,6 @@
               <% @document.rights_uri.each do |rights_uri| %>
                 <%= render_field_row "Rights URI", rights_uri %>
               <% end %>
-            <% else %>
-              <!-- PDC Describe records have a single rights value -->
-              <%= render_field_row "Rights", @document.rights_name_and_uri[:name] %>
-              <%= render_field_row_link "Rights URI", @document.rights_name_and_uri[:uri] %>
             <% end %>
 
             <% @document.rights_holder.each do |rights_holder| %>

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -99,12 +99,21 @@
             <% @document.relation_uri.each do |relation_uri| %>
               <%= render_field_row "Relation URI", relation_uri %>
             <% end %>
-            <% @document.rights.each do |rights| %>
-              <%= render_field_row "Rights", rights %>
+
+            <% if @document.rights_name_and_uri.nil? %>
+              <!-- DSpace records have two unrelated fields -->
+              <% @document.rights.each do |rights| %>
+                <%= render_field_row "Rights", rights %>
+              <% end %>
+              <% @document.rights_uri.each do |rights_uri| %>
+                <%= render_field_row "Rights URI", rights_uri %>
+              <% end %>
+            <% else %>
+              <!-- PDC Describe records have a single rights value -->
+              <%= render_field_row "Rights", @document.rights_name_and_uri[:name] %>
+              <%= render_field_row_link "Rights URI", @document.rights_name_and_uri[:uri] %>
             <% end %>
-            <% @document.rights_uri.each do |rights_uri| %>
-              <%= render_field_row "Rights URI", rights_uri %>
-            <% end %>
+
             <% @document.rights_holder.each do |rights_holder| %>
               <%= render_field_row "Rights Holder", rights_holder %>
             <% end %>

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ImportHelper
+  def self.uri_with_prefix(prefix, value)
+    return nil if value.blank?
+    "#{prefix}/#{value}"
+  end
+
+  def self.doi_uri(value)
+    uri_with_prefix("https://doi.org", value)
+  end
+
+  def self.ark_uri(value)
+    uri_with_prefix("http://arks.princeton.edu", value)
+  end
+end

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -37,7 +37,6 @@ to_field 'uri_ssim' do |record, accumulator, _c|
   accumulator.concat [doi, ark].compact
 end
 
-extract_xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
 # to_field 'collection_id_ssi', extract_xpath('/item/parentCollection/id')
 
 # ==================

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -5,6 +5,7 @@ require 'traject'
 require 'traject/nokogiri_reader'
 require 'blacklight'
 require_relative './domain'
+require_relative './import_helper'
 
 ##
 # If you need to debug PDC Describe indexing, change the log level to Logger::DEBUG
@@ -30,7 +31,13 @@ end
 # to_field 'contributor_tsim', extract_xpath("/item/metadata/key[text()='dcterms.contributor']/../value")
 to_field 'description_tsim', extract_xpath("/hash/description")
 # to_field 'handle_ssim', extract_xpath('/item/handle')
-# to_field 'uri_ssim', extract_xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
+to_field 'uri_ssim' do |record, accumulator, _c|
+  doi = ImportHelper.doi_uri(record.xpath("/hash/doi").text)
+  ark = ImportHelper.ark_uri(record.xpath("/hash/ark").text)
+  accumulator.concat [doi, ark].compact
+end
+
+extract_xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
 # to_field 'collection_id_ssi', extract_xpath('/item/parentCollection/id')
 
 # ==================


### PR DESCRIPTION
Several enhancements to better import PDC Describe records so that they match closely the same records when imported from DSpace.

* Import and display ARK and DOI
* Display Rights Name and Rights URI for PDC Describe records.

Work towards #340 