### PR TITLE
Indexes a few more fields from PDC Describe records 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -91,10 +91,12 @@ class CatalogController < ApplicationController
     #   years_25: { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25} TO *]" }
     # }
 
-    config.add_facet_field 'domain_ssi', label: 'Domain'
+    config.add_facet_field 'domain_ssi', label: 'Domain'                      # DSpace records only
     config.add_facet_field 'community_root_name_ssi', label: 'Community'
-    config.add_facet_field 'subcommunity_name_ssi', label: 'Subcommunity'
+    config.add_facet_field 'subcommunity_name_ssi', label: 'Subcommunity'     # DSpace records only
     config.add_facet_field 'collection_name_ssi', label: 'Collection'
+    config.add_facet_field 'collection_tag_ssim', label: 'Collection Tags'    # PDC Describe records only
+
     config.add_facet_field 'genre_ssim', label: 'Type'
     config.add_facet_field 'year_available_itsi', label: 'Year Published', range: true
 

--- a/app/lib/describe_indexer.rb
+++ b/app/lib/describe_indexer.rb
@@ -39,6 +39,12 @@ class DescribeIndexer
     end
   end
 
+  def index_one(json)
+    xml = JSON.parse(json).to_xml
+    traject_indexer.process(xml)
+    traject_indexer.complete
+  end
+
 private
 
   ##

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -89,6 +89,10 @@ class SolrDocument
     fetch("collection_name_ssi", "")
   end
 
+  def collection_tags
+    fetch("collection_tag_ssim", [])
+  end
+
   def contributors
     fetch("contributor_tsim", [])
   end

--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -12,7 +12,12 @@
             <%= render_field_row_many "Contributor", @document.contributors %>
             <%= render_field_row_search_link "Domain", @document.domain, "domain_ssi" %>
             <%= render_field_row "Community", @document.community_path %>
-            <%= render_field_row "Collection", @document.collection_name %>
+            <% if @document.collection_name.present? %>
+              <%= render_field_row "Collection", @document.collection_name %>
+            <% end %>
+            <% if @document.collection_tags.present? %>
+              <%= render_field_row_many "Collection Tags", @document.collection_tags %>
+            <% end %>
             <%= render_field_row "Date Accessioned", @document.accessioned_date, true %> <!-- displayed by default -->
             <%= render_field_row "Issue date", @document.issued_date, true %> <!-- displayed by default -->
             <%= render_field_row "Date Created", @document.date_created %>

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -28,7 +28,10 @@ end
 
 # to_field 'abstract_tsim', extract_xpath("/item/metadata/key[text()='dcterms.abstract']/../value")
 # to_field 'creator_tesim', extract_xpath("/item/metadata/key[text()='dcterms.creator']/../value")
-# to_field 'contributor_tsim', extract_xpath("/item/metadata/key[text()='dcterms.contributor']/../value")
+to_field 'contributor_tsim' do |record, accumulator, _c|
+  contributor_names = record.xpath("/hash/contributors/contributor/value").map(&:text)
+  accumulator.concat contributor_names
+end
 to_field 'description_tsim', extract_xpath("/hash/description")
 # to_field 'handle_ssim', extract_xpath('/item/handle')
 to_field 'uri_ssim' do |record, accumulator, _c|
@@ -41,77 +44,66 @@ end
 
 # ==================
 # Community and Collections fields
-# Communities can be nested. We gather the community name, the name of the "root" community for the community,
-# and the full path (including nested communities) to the community.
+to_field 'community_name_ssi' do |record, accumulator, _c|
+  # TODO: pick the correct field from the PDC Describe source once it is available
+  # see https://github.com/pulibrary/pdc_describe/issues/841
+  accumulator.concat ["Research Data"]
+end
 
-# to_field 'community_name_ssi' do |record, accumulator, _c|
-#   # We are assuming the largest ID represents the parent community in the tree hierarchy
-#   # (i.e. grandparent nodes were created first and have smaller IDs)
-#   community_id = record.xpath("/item/parentCommunityList/id").map(&:text).map(&:to_i).sort.last
-#   community = settings["dataspace_communities"].find_by_id(community_id)
-#   accumulator.concat [community&.name]
-# end
+to_field 'community_root_name_ssi' do |record, accumulator, _c|
+  # TODO: pick the correct field from the PDC Describe source once it is available
+  # see https://github.com/pulibrary/pdc_describe/issues/841
+  accumulator.concat ["Research Data"]
+end
 
-# to_field 'subcommunity_name_ssi' do |record, accumulator, _c|
-#   byebug
-#   community_id = record.xpath("/item/parentCommunityList/id").map(&:text).map(&:to_i).sort.last
-#   community = settings["dataspace_communities"].find_by_id(community_id)
-#   if community.parent_id
-#     # We only populate this value for subcommunities
-#     accumulator.concat [community.name]
-#   end
-# end
+to_field 'community_path_name_ssi' do |record, accumulator, _c|
+  # TODO: pick the correct field from the PDC Describe source once it is available
+  # see https://github.com/pulibrary/pdc_describe/issues/841
+  accumulator.concat ["Research Data"]
+end
 
-# to_field 'community_root_name_ssi' do |record, accumulator, _c|
-#   community_id = record.xpath("/item/parentCommunityList/id").map(&:text).map(&:to_i).sort.last
-#   root_name = settings["dataspace_communities"].find_root_name(community_id)
-#   accumulator.concat [root_name]
-# end
-
-# to_field 'community_path_name_ssi' do |record, accumulator, _c|
-#   community_id = record.xpath("/item/parentCommunityList/id").map(&:text).map(&:to_i).sort.last
-#   path_name = settings["dataspace_communities"].find_path_name(community_id).join("|")
-#   accumulator.concat [path_name]
-# end
-
-# to_field 'collection_name_ssi' do |record, accumulator, _c|
-#   collection_name = record.xpath("/item/parentCollection/name").map(&:text).first
-#   accumulator.concat [collection_name]
-# end
+to_field 'collection_tag_ssim' do |record, accumulator, _c|
+  collection_tags = record.xpath("/hash/collection-tags/collection-tag").map(&:text)
+  accumulator.concat collection_tags
+end
 
 # ==================
 # author fields
 
 to_field 'author_tesim' do |record, accumulator, _c|
-  author_name = record.xpath("/hash/creators/creator/value").map(&:text)
-  accumulator.concat author_name
+  author_names = record.xpath("/hash/creators/creator/value").map(&:text)
+  accumulator.concat author_names
 end
 
-# # single value is used for sorting
-# to_field 'author_si' do |record, accumulator, _c|
-#   values = record.xpath("/item/metadata/key[text()='dc.contributor.author']/../value").map(&:text)
-#   accumulator.concat [values.uniq.sort.first]
-# end
+# single value is used for sorting
+to_field 'author_si' do |record, accumulator, _c|
+  author_names = record.xpath("/hash/creators/creator/value").map(&:text)
+  accumulator.concat [author_names.uniq.sort.first]
+end
 
-# # all values as strings for faceting
-# to_field 'author_ssim' do |record, accumulator, _c|
-#   values = record.xpath("/item/metadata/key[text()='dc.contributor.author']/../value").map(&:text)
-#   accumulator.concat values.uniq
-# end
+# all values as strings for faceting
+# TODO: Should we include contributors here since the value is for faceting?
+to_field 'author_ssim' do |record, accumulator, _c|
+  author_names = record.xpath("/hash/creators/creator/value").map(&:text)
+  accumulator.concat author_names
+end
 
 # ==================
 # title fields
-to_field 'title_tesim', extract_xpath('/hash/titles/title')
+to_field 'title_tesim' do |record, accumulator, _c|
+  titles = record.xpath('/hash/titles/title').map { |title| title.xpath("./title").text() }
+  accumulator.concat titles
+end
 
-# to_field 'title_si' do |record, accumulator, _c|
-#   values = []
-#   values += record.xpath('/item/name').map(&:text)
-#   values += record.xpath("/item/metadata/key[text()='dcterms.title']/../value").map(&:text)
-#   accumulator.concat [values.uniq.first]
-# end
+to_field 'title_si' do |record, accumulator, _c|
+  main_title = record.xpath('/hash/titles/title').find { |title| title.xpath("./title-type").text() == "" }
+  accumulator.concat [main_title.xpath("./title").text()] unless main_title.nil?
+end
 
-# to_field 'alternative_title_tesim', extract_xpath("/item/metadata/key[text()='dc.title.alternative']/../value")
-# to_field 'alternative_title_tesim', extract_xpath("/item/metadata/key[text()='dcterms.alternative']/../value")
+to_field 'alternative_title_tesim' do |record, accumulator, _c|
+  alternative_titles = record.xpath('/hash/titles/title').select { |title| title.xpath("./title-type").text() != "" }
+  accumulator.concat alternative_titles.map {|title| title.xpath("./title").text() }
+end
 
 # # ==================
 # # Calculate domain from the communities
@@ -323,26 +315,12 @@ to_field 'rights_uri_ssi', extract_xpath("/hash/rights/uri")
 # to_field 'subject_mesh_tesim', extract_xpath("/item/metadata/key[text()='dc.subject.mesh']/../value")
 # to_field 'subject_other_tesim', extract_xpath("/item/metadata/key[text()='dc.subject.other']/../value")
 
-# # subject_all_ssim is used for faceting (must be string)
-# # subject_all_tesim is used for searching (use text english)
-# to_field ['subject_all_ssim', 'subject_all_tesim'] do |record, accumulator, _context|
-#   xpaths = []
-#   xpaths << "/item/metadata/key[text()='dc.subject']/../value"
-#   xpaths << "/item/metadata/key[text()='dcterms.subject']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.classification']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.ddc']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.lcc']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.lcsh']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.mesh']/../value"
-#   xpaths << "/item/metadata/key[text()='dc.subject.other']/../value"
-
-#   values = []
-#   xpaths.each do |xpath|
-#     values += record.xpath(xpath).map(&:text)
-#   end
-
-#   accumulator.concat values.uniq
-# end
+# subject_all_ssim is used for faceting (must be string)
+# subject_all_tesim is used for searching (use text english)
+to_field ['subject_all_ssim', 'subject_all_tesim'] do |record, accumulator, _context|
+  keywords = record.xpath("/hash/keywords/keyword").map(&:text)
+  accumulator.concat keywords
+end
 
 # # ==================
 # # genre, provenance, peer review fields

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -44,19 +44,19 @@ end
 
 # ==================
 # Community and Collections fields
-to_field 'community_name_ssi' do |record, accumulator, _c|
+to_field 'community_name_ssi' do |_record, accumulator, _c|
   # TODO: pick the correct field from the PDC Describe source once it is available
   # see https://github.com/pulibrary/pdc_describe/issues/841
   accumulator.concat ["Research Data"]
 end
 
-to_field 'community_root_name_ssi' do |record, accumulator, _c|
+to_field 'community_root_name_ssi' do |_record, accumulator, _c|
   # TODO: pick the correct field from the PDC Describe source once it is available
   # see https://github.com/pulibrary/pdc_describe/issues/841
   accumulator.concat ["Research Data"]
 end
 
-to_field 'community_path_name_ssi' do |record, accumulator, _c|
+to_field 'community_path_name_ssi' do |_record, accumulator, _c|
   # TODO: pick the correct field from the PDC Describe source once it is available
   # see https://github.com/pulibrary/pdc_describe/issues/841
   accumulator.concat ["Research Data"]
@@ -91,18 +91,18 @@ end
 # ==================
 # title fields
 to_field 'title_tesim' do |record, accumulator, _c|
-  titles = record.xpath('/hash/titles/title').map { |title| title.xpath("./title").text() }
+  titles = record.xpath('/hash/titles/title').map { |title| title.xpath("./title").text }
   accumulator.concat titles
 end
 
 to_field 'title_si' do |record, accumulator, _c|
-  main_title = record.xpath('/hash/titles/title').find { |title| title.xpath("./title-type").text() == "" }
-  accumulator.concat [main_title.xpath("./title").text()] unless main_title.nil?
+  main_title = record.xpath('/hash/titles/title').find { |title| title.xpath("./title-type").text == "" }
+  accumulator.concat [main_title.xpath("./title").text] unless main_title.nil?
 end
 
 to_field 'alternative_title_tesim' do |record, accumulator, _c|
-  alternative_titles = record.xpath('/hash/titles/title').select { |title| title.xpath("./title-type").text() != "" }
-  accumulator.concat alternative_titles.map {|title| title.xpath("./title").text() }
+  alternative_titles = record.xpath('/hash/titles/title').select { |title| title.xpath("./title-type").text != "" }
+  accumulator.concat alternative_titles.map { |title| title.xpath("./title").text }
 end
 
 # # ==================

--- a/spec/fixtures/files/bitklavier.json
+++ b/spec/fixtures/files/bitklavier.json
@@ -1,0 +1,89 @@
+{
+    "titles": [
+        {
+            "title": "bitKlavier Grand Sample Library—Binaural Mic Image",
+            "title_type": null
+        },
+        {
+            "title": "alter title for bitKlavier",
+            "title_type": "AlternativeTitle"
+        }
+    ],
+    "description": "The bitKlavier Grand consists of sample collections of a new Steinway D grand piano from nine different stereo mic images, with: 16 velocity layers, at every minor 3rd (starting at A0); Hammer release samples; Release resonance samples; Pedal samples. Release packages at 96k/24bit, 88.2k/24bit, 48k/24bit, 44.1k/16bit are available for various applications.\r\n  Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnidirectional microphones within the piano. The bar is placed across the harp near the hammers and provides a low string / high string player’s perspective. It also produces a close sound without room or lid interactions. It can be panned across an artificial stereophonic perspective effectively in post-production. File Naming Convention: C4 = middle C. Main note names: [note name][octave]v[velocity].wav -- e.g., “D#5v13.wav”. Release resonance notes: harm[note name][octave]v[velocity].wav -- e.g., “harmC2v2.wav”. Hammer samples: rel[1-88].wav (one per key) -- e.g., “rel23.wav”. Pedal samples: pedal[D/U][velocity].wav -- e.g., “pedalU2.wav” =\u003e pedal release (U = up), velocity = 2 (quicker release than velocity = 1).\r\n  This dataset is too large to download directly from this item page. You can access and download the data via Globus (See https://www.youtube.com/watch?v=uf2c7Y1fiFs for instructions on how to use Globus).",
+    "collection_tags": [
+        "Humanities",
+        "Something else"
+    ],
+    "creators": [
+        {
+            "value": "Trueman, Daniel",
+            "name_type": "Personal",
+            "given_name": "Daniel",
+            "family_name": "Trueman",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 1
+        }
+    ],
+    "resource_type": "Dataset",
+    "resource_type_general": "Dataset",
+    "publisher": "Princeton University",
+    "publication_year": "2021",
+    "ark": "ark:/88435/dsp015999n653h",
+    "doi": "10.34770/r75s-9j74",
+    "rights": {
+        "identifier": "GPLv3",
+        "uri": "https://www.gnu.org/licenses/gpl-3.0.en.html",
+        "name": "GNU General Public License"
+    },
+    "version_number": "1",
+    "related_objects": [],
+    "keywords": [
+        "keyword1",
+        "keyword2",
+        "keyword3"
+    ],
+    "contributors": [
+        {
+            "value": "Villalta, Andrés",
+            "name_type": "Personal",
+            "given_name": "Andrés",
+            "family_name": "Villalta",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 0,
+            "type": "CONTACT_PERSON"
+        },
+        {
+            "value": "Chou, Katie",
+            "name_type": "Personal",
+            "given_name": "Katie",
+            "family_name": "Chou",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 0,
+            "type": "CONTACT_PERSON"
+        },
+        {
+            "value": "Ayres, Christien",
+            "name_type": "Personal",
+            "given_name": "Christien",
+            "family_name": "Ayres",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 0,
+            "type": "CONTACT_PERSON"
+        },
+        {
+            "value": "Wang, Matthew",
+            "name_type": "Personal",
+            "given_name": "Matthew",
+            "family_name": "Wang",
+            "identifier": null,
+            "affiliations": [],
+            "sequence": 1,
+            "type": "CONTACT_PERSON"
+        }
+    ],
+    "funders": []
+}

--- a/spec/lib/describe_indexer_spec.rb
+++ b/spec/lib/describe_indexer_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe DescribeIndexer do
+  describe 'indexing a single record' do
+    let(:single_item) { file_fixture("bitklavier.json").read }
+    let(:indexer) do
+      described_class.new(rss_url: "file://whatever.rss")
+    end
+    let(:indexed_record) do
+      Blacklight.default_index.connection.delete_by_query("*:*")
+      Blacklight.default_index.connection.commit
+      indexer.index_one(single_item)
+      response = Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+      response["response"]["docs"].first
+    end
+
+    context "basic fields" do
+      it "author" do
+        expect(indexed_record["author_tesim"]).to eq ['Trueman, Daniel']
+      end
+
+      it "description" do
+        description = "The bitKlavier Grand consists"
+        expect(indexed_record["description_tsim"].first.include?(description)).to be true
+      end
+
+      it "contributors" do
+        expect(indexed_record["contributor_tsim"].include?("Villalta, Andrés")).to eq true
+        expect(indexed_record["contributor_tsim"].include?("Chou, Katie")).to eq true
+        expect(indexed_record["contributor_tsim"].include?("Ayres, Christien")).to eq true
+        expect(indexed_record["contributor_tsim"].include?("Wang, Matthew")).to eq true
+      end
+
+      it "title" do
+        # title includes all titles
+        main_title = "bitKlavier Grand Sample Library—Binaural Mic Image"
+        alt_title = "alter title for bitKlavier"
+        expect(indexed_record["title_tesim"].include?(main_title)).to eq true
+        expect(indexed_record["title_tesim"].include?(alt_title)).to eq true
+        # alt title does not include the main title
+        expect(indexed_record["alternative_title_tesim"].include?(main_title)).to eq false
+        expect(indexed_record["alternative_title_tesim"].include?(alt_title)).to eq true
+      end
+
+      it "rights" do
+        expect(indexed_record["rights_name_ssi"]).to eq "GNU General Public License"
+        expect(indexed_record["rights_uri_ssi"]).to eq "https://www.gnu.org/licenses/gpl-3.0.en.html"
+      end
+
+      it "keywords" do
+        expect(indexed_record["subject_all_ssim"].include?("keyword1")).to eq true
+        expect(indexed_record["subject_all_ssim"].include?("keyword2")).to eq true
+        expect(indexed_record["subject_all_ssim"].include?("keyword3")).to eq true
+      end
+
+      it "collection tag" do
+        expect(indexed_record["collection_tag_ssim"].include?("Humanities")).to eq true
+        expect(indexed_record["collection_tag_ssim"].include?("Something else")).to eq true
+      end
+
+      it "community" do
+        expect(indexed_record["community_name_ssi"]).to eq "Research Data"
+      end
+
+      it "genre_ssim" do
+        expect(indexed_record["genre_ssim"].first).to eq "Dataset"
+      end
+
+      it "issue_date_ssim" do
+        expect(indexed_record["issue_date_ssim"].first).to eq "2021"
+      end
+
+      it "publisher_ssim" do
+        expect(indexed_record["publisher_ssim"].first).to eq "Princeton University"
+      end
+    end
+
+    context "uris" do
+      it "stores full URL for ARK and DOI" do
+        expect(indexed_record["uri_ssim"].include?("http://arks.princeton.edu/ark:/88435/dsp015999n653h")).to eq true
+        expect(indexed_record["uri_ssim"].include?("https://doi.org/10.34770/r75s-9j74")).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Indexes a few more fields from PDC Describe records and updates the UI to account for a few discrepancies on where the data is located between PDC Describe and DSpace records.

Fields included are: 
* Collection (hard-coded for now, see https://github.com/pulibrary/pdc_discovery/issues/373)
* Collection Tags (new, i.e. not in DSpace records)
* Contributors
* Authors (including value for sorting)
* Titles (including multiple titles and title for sorting)
* Subject (i.e. "keywords" in PDC Describe)

Part of https://github.com/pulibrary/pdc_discovery/issues/340