### PR TITLE
Log errors when importing from PDC Describe

### DIFF
--- a/app/lib/describe_indexer.rb
+++ b/app/lib/describe_indexer.rb
@@ -56,6 +56,8 @@ private
       resource_json = URI.open(url).read
       resource_xml = JSON.parse(resource_json).to_xml
       traject_indexer.process(resource_xml)
+    rescue => ex
+      Rails.logger.warn "Error importing record from #{url}. Exception: ##{ex.message}"
     end
   end
 end


### PR DESCRIPTION
Logs error and skip records instead of just bailing out of the entire import process when a PDC Describe record does not return a proper JSON representation.

See https://github.com/pulibrary/pdc_describe/issues/870
