### PR TITLE
Give priority to PDC Describe records when indexing records

### DIFF
--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -19,8 +19,7 @@ end
 
 each_record do |record, context|
   uris = record.xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
-  ark_uri = uris.find { |uri| uri.text.start_with?("http://arks.princeton.edu/ark:/") }&.text
-  if ImportHelper.pdc_describe_match_found?(ark_uri)
+  if ImportHelper.pdc_describe_match?(uris)
     id = record.xpath('/item/id')
     context.skip!("Skipping DataSpace record #{id} - already imported from PDC Describe")
   end

--- a/lib/traject/dataspace_research_data_config.rb
+++ b/lib/traject/dataspace_research_data_config.rb
@@ -5,6 +5,7 @@ require 'traject'
 require 'traject/nokogiri_reader'
 require 'blacklight'
 require_relative './domain'
+require_relative './import_helper'
 
 settings do
   provide 'solr.url', Blacklight.default_index.connection.uri.to_s
@@ -14,6 +15,15 @@ settings do
   provide 'logger', Logger.new($stderr, level: Logger::ERROR)
   provide "nokogiri.each_record_xpath", "//items/item"
   provide "dataspace_communities", DataspaceCommunities.new('./spec/fixtures/files/dataspace_communities.json')
+end
+
+each_record do |record, context|
+  uris = record.xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
+  ark_uri = uris.find { |uri| uri.text.start_with?("http://arks.princeton.edu/ark:/") }&.text
+  if ImportHelper.pdc_describe_match_found?(ark_uri)
+    id = record.xpath('/item/id')
+    context.skip!("Skipping DataSpace record #{id} - already imported from PDC Describe")
+  end
 end
 
 # ==================
@@ -31,6 +41,11 @@ to_field 'id', extract_xpath('/item/id')
 to_field 'uri_ssim', extract_xpath("/item/metadata/key[text()='dc.identifier.uri']/../value")
 to_field 'collection_id_ssi', extract_xpath('/item/parentCollection/id')
 to_field 'handle_ssi', extract_xpath('/item/handle')
+
+# Track the source of this record
+to_field 'data_source_ssi' do |_record, accumulator, _c|
+  accumulator.concat ["dataspace"]
+end
 
 # ==================
 # Community and Collections fields

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -13,4 +13,13 @@ class ImportHelper
   def self.ark_uri(value)
     uri_with_prefix("http://arks.princeton.edu", value)
   end
+
+  # Returns true if a record already exists in Solr with this ARK as one of the URIs
+  # and that record was imported from PDC Describe.
+  def self.pdc_describe_match_found?(ark_uri)
+    return false if ark_uri.nil?
+    solr_query = "#{Blacklight.default_index.connection.uri}select?q=uri_ssim:#{ark_uri}+AND+data_source_ssi:pdc_describe"
+    solr_response = JSON.parse(URI.open(solr_query).read)
+    solr_response["response"]["numFound"] != 0
+  end
 end

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -18,7 +18,7 @@ class ImportHelper
   # and that record was imported from PDC Describe.
   def self.pdc_describe_match_found?(ark_uri)
     return false if ark_uri.nil?
-    solr_query = "#{Blacklight.default_index.connection.uri}select?q=uri_ssim:#{ark_uri}+AND+data_source_ssi:pdc_describe"
+    solr_query = "#{Blacklight.default_index.connection.uri}select?q=data_source_ssi:pdc_describe+AND+uri_ssim:#{ark_uri}"
     solr_response = JSON.parse(URI.open(solr_query).read)
     solr_response["response"]["numFound"] != 0
   end

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -18,11 +18,8 @@ class ImportHelper
   # and that record was imported from PDC Describe.
   def self.pdc_describe_match_found?(ark_uri)
     return false if ark_uri.nil?
-    puts "==HECTOR-WAS-HERE=="
-    puts "base: #{Blacklight.default_index.connection.uri}"
     solr_query = "#{Blacklight.default_index.connection.uri}select?q=data_source_ssi:pdc_describe+AND+uri_ssim:#{ark_uri}"
-    puts "query: #{solr_query}"
-    solr_response = JSON.parse(URI.open(solr_query).read)
-    solr_response["response"]["numFound"] != 0
+    response = HTTParty.get(solr_query)
+    response.parsed_response["response"]["numFound"] != 0
   end
 end

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -14,11 +14,23 @@ class ImportHelper
     uri_with_prefix("http://arks.princeton.edu", value)
   end
 
-  # Returns true if a record already exists in Solr with this ARK as one of the URIs
+  # Returns true if a record already exists in Solr for the given URIs
   # and that record was imported from PDC Describe.
-  def self.pdc_describe_match_found?(ark_uri)
-    return false if ark_uri.nil?
-    solr_query = "#{Blacklight.default_index.connection.uri}select?q=data_source_ssi:pdc_describe+AND+uri_ssim:#{ark_uri}"
+  def self.pdc_describe_match?(uris)
+    ark_uri = uris.find { |uri| uri.text.start_with?("http://arks.princeton.edu/ark:/") }&.text
+    return true if pdc_describe_match_by_uri?(ark_uri)
+
+    doi_uri = uris.find { |uri| uri.text.start_with?("https://doi.org/10.34770/") }&.text
+    return true if pdc_describe_match_by_uri?(doi_uri)
+
+    false
+  end
+
+  # Returns true if a record already exists in Solr for the given URI
+  # provided and that record was imported from PDC Describe.
+  def self.pdc_describe_match_by_uri?(uri)
+    return false if uri.nil?
+    solr_query = "#{Blacklight.default_index.connection.uri}select?q=data_source_ssi:pdc_describe+AND+uri_ssim:#{uri}"
     response = HTTParty.get(solr_query)
     response.parsed_response["response"]["numFound"] != 0
   end

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -18,7 +18,10 @@ class ImportHelper
   # and that record was imported from PDC Describe.
   def self.pdc_describe_match_found?(ark_uri)
     return false if ark_uri.nil?
+    puts "==HECTOR-WAS-HERE=="
+    puts "base: #{Blacklight.default_index.connection.uri}"
     solr_query = "#{Blacklight.default_index.connection.uri}select?q=data_source_ssi:pdc_describe+AND+uri_ssim:#{ark_uri}"
+    puts "query: #{solr_query}"
     solr_response = JSON.parse(URI.open(solr_query).read)
     solr_response["response"]["numFound"] != 0
   end

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -26,6 +26,11 @@ to_field 'id' do |record, accumulator, _c|
   accumulator.concat [munged_doi]
 end
 
+# Track the source of this record
+to_field 'data_source_ssi' do |_record, accumulator, _c|
+  accumulator.concat ["pdc_describe"]
+end
+
 # to_field 'abstract_tsim', extract_xpath("/item/metadata/key[text()='dcterms.abstract']/../value")
 # to_field 'creator_tesim', extract_xpath("/item/metadata/key[text()='dcterms.creator']/../value")
 to_field 'contributor_tsim' do |record, accumulator, _c|

--- a/spec/lib/dspace_indexer_spec.rb
+++ b/spec/lib/dspace_indexer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe DspaceIndexer do
       end
 
       it "skips records already imported from PDC Describe" do
+        # q=data_source_ssi:pdc_describe AND uri_ssim:http://arks.princeton.edu/ark:/88435/dsp017s75df84b
         solr_query_regex = /.*q=data_source_ssi\:pdc_describe\sAND\suri_ssim\:http\:\/\/arks.princeton.edu\/ark\:\/88435\/dsp017s75df84b/
         stub_request(:get, solr_query_regex).to_return(status: 200, body: '{"response":{"numFound":1}}', headers: {})
 

--- a/spec/lib/dspace_indexer_spec.rb
+++ b/spec/lib/dspace_indexer_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe DspaceIndexer do
         response = Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
         expect(response["response"]["numFound"]).to eq 39
       end
+
+      it "skips records already imported from PDC Describe" do
+        solr_query_regex = /.*q=data_source_ssi\:pdc_describe\sAND\suri_ssim\:http\:\/\/arks.princeton.edu\/ark\:\/88435\/dsp017s75df84b/
+        stub_request(:get, solr_query_regex).to_return(status: 200, body: '{"response":{"numFound":1}}', headers: {})
+
+        response = Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+        expect(response["response"]["numFound"]).to eq 0
+        indexer.index
+        response = Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+        expect(response["response"]["numFound"]).to eq 38
+      end
     end
 
     context 'invoking from CLI' do


### PR DESCRIPTION
When importing DataSpace records, skip those that have matching records already imported from PDC Describe. The match is done via the ARK or DOI from DataSpace.

The logic get executed regardless of how we import the data:

```
# Importing all research data (PDC Describe + DataSpace)
bundle exec rake index:research_data

# Importing from DataSpace
bundle exec rake index:dspace_research_data

# Importing from PDC Describe (no changes here)
bundle exec rake index:pdc_describe_research_data 
```

Fixes #375 
