### PR TITLE
Render collection tags as links to a search by the collection tag facet

### DIFF
--- a/app/views/catalog/_show_metadata.html.erb
+++ b/app/views/catalog/_show_metadata.html.erb
@@ -16,7 +16,7 @@
               <%= render_field_row "Collection", @document.collection_name %>
             <% end %>
             <% if @document.collection_tags.present? %>
-              <%= render_field_row_many "Collection Tags", @document.collection_tags %>
+              <%= render_field_row_search_links "Collection Tags", @document.collection_tags, "collection_tag_ssim" %>
             <% end %>
             <%= render_field_row "Date Accessioned", @document.accessioned_date, true %> <!-- displayed by default -->
             <%= render_field_row "Issue date", @document.issued_date, true %> <!-- displayed by default -->

--- a/spec/system/bitklavier_single_item_metadata_spec.rb
+++ b/spec/system/bitklavier_single_item_metadata_spec.rb
@@ -39,6 +39,14 @@ describe 'PDC Describe Bitklavier Single item page', type: :system, js: true do
   end
   # rubocop:enable RSpec/ExampleLength
 
+  it "renders collection tags as links" do
+    visit '/catalog/doi-10-34770-r75s-9j74'
+    tag1 = "<a href=\"/?f[collection_tag_ssim][]=Humanities"
+    tag2 = "<a href=\"/?f[collection_tag_ssim][]=Something+else"
+    expect(page.html.include?(tag1)).to be true
+    expect(page.html.include?(tag2)).to be true
+  end
+
   # rubocop:disable Layout/LineLength
   xit "has expected citation information" do
     visit '/catalog/78348'


### PR DESCRIPTION
This will make the data imported from https://github.com/pulibrary/pdc_describe/issues/820 now searchable from within PDC Discovery.

![Screenshot 2023-01-23 at 3 33 41 PM](https://user-images.githubusercontent.com/568286/214144099-67ff1425-9254-4715-a349-9e96955bdf52.png)

