### PR TITLE
Uses URL from PDC describe records

### DIFF
--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -345,13 +345,11 @@ to_field 'genre_ssim', extract_xpath("/hash/resource/resource-type")
 # ==================
 # Store all files metadata as a single JSON string so that we can display detailed information for each of them.
 to_field 'files_ss' do |record, accumulator, _context|
-  # TODO: Remove prefix once we export the complete URI in PDC Describe
-  url_prefix = "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration"
   files = record.xpath("/hash/files/file").map do |file|
     {
       name: File.basename(file.xpath("filename").text),
       size: file.xpath("size").text,
-      url: "#{url_prefix}/#{file.xpath('filename').text}"
+      url: file.xpath('url').text
     }
   end
   accumulator.concat [files.to_json.to_s]

--- a/spec/fixtures/files/bitklavier_binaural.json
+++ b/spec/fixtures/files/bitklavier_binaural.json
@@ -91,11 +91,13 @@
     "files": [
         {
             "filename": "10.80021/3m1k-6036/122/file1.jpg",
-            "size": 316781
+            "size": 316781,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file1.jpg"
         },
         {
             "filename": "10.80021/3m1k-6036/122/file2.txt",
-            "size": 396003
+            "size": 396003,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file2.txt"
         }
     ],
     "collection": {

--- a/spec/lib/describe_indexer_spec.rb
+++ b/spec/lib/describe_indexer_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe DescribeIndexer do
         file1 = files.find { |file| file["name"] == "file1.jpg" }
         file2 = files.find { |file| file["name"] == "file2.txt" }
         expect(file1["size"]).to eq "316781"
+        expect(file1["url"]).to eq "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file1.jpg"
         expect(file2["size"]).to eq "396003"
       end
     end


### PR DESCRIPTION
Now that PDC Discovery include the URL for each file we use that value rather than building the URL on the fly with hard-coded values.

Closes https://github.com/pulibrary/pdc_describe/issues/902

