### PR TITLE
Fixes issue with reindex in production

### DIFF
--- a/app/lib/dspace_research_data_harvester.rb
+++ b/app/lib/dspace_research_data_harvester.rb
@@ -38,7 +38,7 @@ class DspaceResearchDataHarvester
   # @example
   #   DspaceResearchDataHarvester.harvest
   def self.harvest(use_cache = false)
-    Rails.logger.info "Harvesting and indexing research data collections"
+    Rails.logger.info "Harvesting and indexing research data collections has started"
 
     unless use_cache
       # Fetch latest community information from DataSpace
@@ -52,6 +52,6 @@ class DspaceResearchDataHarvester
       Rails.logger.info "Harvesting collection id #{collection.collection_id}"
       r.harvest(collection)
     end
-    Rails.logger.info "Done harvesting research data."
+    Rails.logger.info "Harvesting and indexing research data collections has completed"
   end
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -3,33 +3,30 @@
 namespace :index do
   desc 'Delete index and re-index all research data'
   task research_data: :environment do
-    puts "Deleting index..."
-    Rake::Task['index:delete'].invoke
-    puts "Indexing PDC Describe data..."
+    Rails.logger.info "Research Data indexing started"
+    Rake::Task['index:delete_solr_all'].invoke
     Rake::Task['index:pdc_describe_research_data'].invoke
-    puts "Indexing Data Space research data collections..."
     Rake::Task['index:dspace_research_data'].invoke
-    puts "Done."
+    Rails.logger.info "Research Data indexing completed"
   end
 
   desc 'Index all DSpace research data collections'
   task dspace_research_data: :environment do
-    puts "Harvesting and indexing DataSpace research data collections"
+    Rails.logger.info "Harvesting and indexing DataSpace research data collections started"
     DspaceResearchDataHarvester.harvest(false)
-    puts "Done harvesting DataSpace research data."
+    Rails.logger.info "Harvesting and indexing DataSpace research data collections completed"
   end
 
   desc 'Index all PDC Describe data'
   task pdc_describe_research_data: :environment do
-    puts "Harvesting and indexing PDC Describe data"
+    Rails.logger.info "Harvesting and indexing PDC Describe data started"
     DescribeIndexer.new.index
-    puts "Done harvesting PDC Describe data."
+    Rails.logger.info "Harvesting and indexing PDC Describe data completed"
   end
 
   desc 'Remove all indexed Documents from Solr'
-  task delete: :environment do
-    raise("Deleting indices in Solr is unsupported for the environment #{Rails.env}") if Rails.env.production?
-
+  task delete_solr_all: :environment do
+    Rails.logger.info "Deleting all Solr documents"
     Blacklight.default_index.connection.delete_by_query('*:*')
     Blacklight.default_index.connection.commit
   end


### PR DESCRIPTION
The reindex in production was throwing an error because it invokes a delete before starting (which is needed) but we had an extra guard that was preventing the delete. 

I removed the guard so that the delete executes as expected, but I did make the name of the delete task a bit more explicit (from `delete` to `delete_all_solr`) so that at least we know what we are deleting when we call it.

I also moved the logging to the Rails logger so we have a record.

Closes #399 