### PR TITLE
Add a link to the accessibility form

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -25,7 +25,23 @@
       }
 
       @media all and (min-width: 765px) {
-        flex-basis: calc(25% - 2rem);
+        flex-basis: calc(20% - 2rem);
+      }
+    }
+
+    .pul-accessible a {
+      color: black;
+      &::after {
+        background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiA/PjxzdmcgZmlsbD0ibm9uZSIgaGVpZ2h0PSIyNCIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIHN0cm9rZS13aWR0aD0iMiIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTE4IDEzdjZhMiAyIDAgMCAxLTIgMkg1YTIgMiAwIDAgMS0yLTJWOGEyIDIgMCAwIDEgMi0yaDYiLz48cG9seWxpbmUgcG9pbnRzPSIxNSAzIDIxIDMgMjEgOSIvPjxsaW5lIHgxPSIxMCIgeDI9IjIxIiB5MT0iMTQiIHkyPSIzIi8+PC9zdmc+");
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: contain;
+        content: "";
+        display: inline-block;
+        height: 12px;
+        margin-left: 8px;
+        position: relative;
+        width: 12px;
       }
     }
   }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -18,6 +18,9 @@
   </div>
   <div id="footer">
     <div class="content">
+      <div class= "pul-accessible">
+        <%= link_to("Accessibility","https://accessibility.princeton.edu/help", target:"blank") %>
+      </div>
       <%= link_to(image_tag("pul_logo_0.png", alt: "Princeton University Library"), "https://library.princeton.edu", target: "blank") %>
       <%= link_to(image_tag("footer_logo.png", alt: "Princeton Research Data Service"), "https://researchdata.princeton.edu", target: "blank") %>
       <%= link_to(image_tag("princeton_research_logo_2.png", alt: "Office for the Dean of Research"), "https://research.princeton.edu", target: "blank") %>

--- a/spec/system/front_page_spec.rb
+++ b/spec/system/front_page_spec.rb
@@ -26,5 +26,6 @@ describe 'Application landing page', type: :system do
     expect(page).to have_link "Home", href: "/"
     expect(page).to have_link "About", href: "/about"
     expect(page).to have_link "How to Submit", href: "/submit"
+    expect(page).to have_link "Accessibility", href: "https://accessibility.princeton.edu/help"
   end
 end


### PR DESCRIPTION
Copied SVG from the [library home page](https://github.com/pulibrary/pul_library_drupal/blob/2fb76174c40480bfb96b21d00a7f30597daaabc1/sites/all/themes/pul_base/assets/source/styles/components/_footer.scss#L41-L53 ) for consistent look and feel 

fixes:
 * #394

![Screenshot 2023-03-27 at 2 00 41 PM](https://user-images.githubusercontent.com/1599081/228031782-c92ed078-7bb8-44e4-8e64-19d19764e408.png)
