### PR TITLE
Fixes the reindex configuration 

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-server "pdc-discovery-prod1.princeton.edu", user: "deploy", roles: %w[app db web]
+server "pdc-discovery-prod1.princeton.edu", user: "deploy", roles: %w[app db web reindex]
 server "pdc-discovery-prod2.princeton.edu", user: "deploy", roles: %w[app db web]

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -23,6 +23,6 @@
 # Sets the PATH environment variable and run the job
 set :job_template, "bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && :job'"
 
-every :day, at: '12:20am', roles: [:app] do
+every :day, at: '12:20am', roles: [:reindex] do
   rake "index:research_data"
 end


### PR DESCRIPTION
Designates one of the production servers with the reindex role. Makes sure the reindex job is scheduled on the reindex role (not on the app role).

Closes #403 