### PR TITLE
ruby upgrade for jammy

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-ruby 3.0.3
+ruby 3.1.0
 nodejs 16.15.0
 yarn 1.22.19

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.3'
+ruby '3.1.0'
 
+gem 'net-ssh', '7.0.0.beta1'
 gem 'bcrypt', '~> 3.1.7'
 gem 'blacklight', '>= 7.0'
 gem 'blacklight_dynamic_sitemap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
       net-ssh (>= 2.6.5, < 7.0.0)
     net-smtp (0.3.3)
       net-protocol
-    net-ssh (6.1.0)
+    net-ssh (7.0.0.beta1)
     nio4r (2.5.8)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
@@ -558,6 +558,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.3)
   multi_xml
+  net-ssh (= 7.0.0.beta1)
   nokogiri (>= 1.13.4)
   oai
   pg
@@ -588,7 +589,7 @@ DEPENDENCIES
   whenever
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.0p0
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
it fails with an openssl error that is resolved by this update
the update for the gem allows non-rsa keys to work
