### PR TITLE
Don't delete records during routine reindexing

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,5 +24,5 @@
 set :job_template, "bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && :job'"
 
 every :day, at: '12:20am', roles: [:reindex] do
-  rake "index:research_data"
+  rake "index:research_data_clean_slate"
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -2,9 +2,16 @@
 
 namespace :index do
   desc 'Delete index and re-index all research data'
+  task research_data_clean_slate: :environment do
+    Rails.logger.info "Deleting all Solr documents"
+    Rake::Task['index:delete_solr_all'].invoke
+    Rails.logger.info "Deleted all Solr documents"
+    Rake::Task['index:research_data'].invoke
+  end
+
+  desc 'Re-index all research data (without deleting first)'
   task research_data: :environment do
     Rails.logger.info "Research Data indexing started"
-    Rake::Task['index:delete_solr_all'].invoke
     Rake::Task['index:pdc_describe_research_data'].invoke
     Rake::Task['index:dspace_research_data'].invoke
     Rails.logger.info "Research Data indexing completed"


### PR DESCRIPTION
Updated the code to prevent it from deleting all the documents before reindexing unless explicitly requested.

This will prevent the entire index from being deleted immediately after a typical release of the application (which results in a 1-2 minutes of inconsistent data) that looks like a 1-2 minute outage to users.

We still keep the delete and reindex on the scheduled task that runs at night, though.

Fixes #404 