### PR TITLE
Display authors in order and include their ORCID 

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -111,7 +111,13 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
+
+    # Notice that for the author field we key of the `author_tesim` field but in reality
+    # we render a different value (see the helper). We use `author_tesim` in here because
+    # that is a common field between all our records, the ones coming from DataSpace
+    # and the ones coming from PDC Describe.
     config.add_index_field 'author_tesim', label: 'Author(s)', helper_method: :authors_search_results_helper
+
     config.add_index_field 'format', label: 'Format'
     config.add_index_field 'abstract_tsim', label: 'Abstract'
     config.add_index_field 'published_ssim', label: 'Published'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -223,7 +223,7 @@ module ApplicationHelper
     name = author["value"]
     return if name.blank?
 
-    orcid = author.dig("identifier", "value") if author.dig("identifier", "scheme") == "ORCID"
+    orcid = author.dig("identifier", "value") if author.dig("identifier", "scheme")&.upcase  == "ORCID"
     icon_html = '<i class="bi bi-person-fill"></i>'
     separator = add_separator ? ";" : ""
     name_html = "#{name}#{separator}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,19 +216,20 @@ module ApplicationHelper
   end
 
   def authors_search_results_helper(field)
-    field[:value].join("; ")
+    field[:document].authors_ordered.map { |author| author["value"] }.join("; ")
   end
 
-  def render_author(name, add_separator)
+  def render_author(author, add_separator)
+    name = author["value"]
     return if name.blank?
 
+    orcid = author.dig("identifier", "value") if author.dig("identifier", "scheme") == "ORCID"
     icon_html = '<i class="bi bi-person-fill"></i>'
     separator = add_separator ? ";" : ""
     name_html = "#{name}#{separator}"
-    if name == 'Koeser, Rebecca Sutton'
-      # Hard-coded for now to demo how researchers with ORCiD will display
+    if orcid
       icon_html = '<img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />'
-      name_html = '<a href="https://orcid.org/0000-0002-8762-8057" target="_blank">' + name + '</a>' + separator
+      name_html = '<a href="https://orcid.org/' + orcid + '" target="_blank">' + name + '</a>' + separator
     end
 
     html = <<-HTML

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -223,7 +223,7 @@ module ApplicationHelper
     name = author["value"]
     return if name.blank?
 
-    orcid = author.dig("identifier", "value") if author.dig("identifier", "scheme")&.upcase  == "ORCID"
+    orcid = author.dig("identifier", "value") if author.dig("identifier", "scheme")&.upcase == "ORCID"
     icon_html = '<i class="bi bi-person-fill"></i>'
     separator = add_separator ? ";" : ""
     name_html = "#{name}#{separator}"

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -62,20 +62,24 @@ class SolrDocument
     titles.first
   end
 
+  # Returns the list of author names (ordered if possible)
   def authors
-    fetch('author_tesim', [])
+    authors_ordered.map { |author| author["value"] }
   end
 
+  # Returns the list of authors with all their information
+  # including name and ORCID. (ordered if possible)
   def authors_ordered
     @authors_ordered ||= begin
       pdc_describe_json = fetch('pdc_describe_json_ss', nil)
       if pdc_describe_json
-        # Sort the data by the sequence
+        # Get the author data and sort it
         record = JSON.parse(pdc_describe_json)
         record["resource"]["creators"].sort_by { |creator| creator["sequence"] }
       else
         # Do the best we can with DataSpace records
-        authors.map { |name| author_from_name(name) }
+        names = fetch('author_tesim', [])
+        names.map { |name| author_from_name(name) }
       end
     end
   end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -71,13 +71,15 @@ class SolrDocument
   # including name and ORCID. (ordered if possible)
   def authors_ordered
     @authors_ordered ||= begin
-      pdc_describe_json = fetch('pdc_describe_json_ss', nil)
-      if pdc_describe_json
-        # Get the author data and sort it
-        record = JSON.parse(pdc_describe_json)
-        record["resource"]["creators"].sort_by { |creator| creator["sequence"] }
+      authors_json = fetch('authors_json_ss', nil)
+      if authors_json
+        # PDC Describe records contain this field;
+        # det the author data and sort it.
+        authors = JSON.parse(authors_json)
+        authors.sort_by { |creator| creator["sequence"] }
       else
-        # Do the best we can with DataSpace records
+        # DataSpace record don't contain this field;
+        # do the best we can with author_tesim value.
         names = fetch('author_tesim', [])
         names.map { |name| author_from_name(name) }
       end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -21,7 +21,7 @@
         <h1 class="index_title document-title-heading col">
           <span itemprop="name"><%= @document.title %></span>
         </h1>
-        <% @document.authors.each_with_index do |author, ix| %>
+        <% @document.authors_ordered.each_with_index do |author, ix| %>
           <%= render_author(author, ix < (@document.authors.count-1)) %>
         <% end %>
       </div>
@@ -48,7 +48,6 @@
         <dd class="col-md-12 abstract-container">
           <div class="document-abstract">
             <header>Abstract:</header>
-            
             <p id="document-abstract-text" class="truncate-line-clamp"><%== Rinku.auto_link(abstract, mode=:all, link_attr=nil, skip_tags=nil) %></p>
             <a id="document-abstract-text-toggle" href="#"><i class="bi bi-caret-down"></i><span>Show More</span></a>
           </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -22,7 +22,7 @@
           <span itemprop="name"><%= @document.title %></span>
         </h1>
         <% @document.authors_ordered.each_with_index do |author, ix| %>
-          <%= render_author(author, ix < (@document.authors.count-1)) %>
+          <%= render_author(author, ix < (@document.authors_ordered.count-1)) %>
         <% end %>
       </div>
     </header>

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -83,6 +83,13 @@ to_field 'author_ssim' do |record, accumulator, _c|
   accumulator.concat author_names
 end
 
+# Extract the author data from the pdc_describe_json and save it on its own field as JSON
+to_field 'authors_json_ss' do |record, accumulator, _c|
+  pdc_json = record.xpath("/hash/pdc_describe_json/text()").first.content
+  authors = JSON.parse(pdc_json).dig("resource", "creators") || []
+  accumulator.concat [authors.to_json]
+end
+
 # ==================
 # title fields
 to_field 'title_tesim' do |record, accumulator, _c|

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -50,5 +50,25 @@ RSpec.describe SolrDocument do
       expect(doc.file_counts[1]).to eq csv_group
     end
   end
+
+  describe "#authors_ordered" do
+    it "handles order for PDC Describe records" do
+      pdc_describe_data = File.read(File.join(fixture_path, 'files', 'pppl1.json'))
+      doc = described_class.new({ id: "1", pdc_describe_json_ss: pdc_describe_data })
+      expect(doc.authors_ordered.first["sequence"]).to eq 1
+      expect(doc.authors_ordered.first["value"]).to eq "Wang, Yin"
+      expect(doc.authors_ordered.last["sequence"]).to eq 5
+      expect(doc.authors_ordered.last["value"]).to eq "Ji, Hantao"
+      expect(doc.authors_ordered.count).to eq 5
+    end
+
+    it "returns the authors unordered DataSpace records" do
+      doc = described_class.new({ id: "1", author_tesim: ["Eve Tuck", "K. Wayne Yang"] })
+      expect(doc.authors_ordered.first["sequence"]).to eq 0
+      expect(doc.authors_ordered.last["sequence"]).to eq 0
+      expect(doc.authors_ordered.any?{ |author| author["value"] == "Eve Tuck"}).to eq true
+      expect(doc.authors_ordered.count).to eq 2
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe SolrDocument do
   describe "#authors_ordered" do
     it "handles order for PDC Describe records" do
       pdc_describe_data = File.read(File.join(fixture_path, 'files', 'pppl1.json'))
-      doc = described_class.new({ id: "1", pdc_describe_json_ss: pdc_describe_data })
+      pdc_authors = pdc_describe_data["resource"]["creators"].to_json
+      doc = described_class.new({ id: "1", authors_json_ss: pdc_authors })
       expect(doc.authors_ordered.first["sequence"]).to eq 1
       expect(doc.authors_ordered.first["value"]).to eq "Wang, Yin"
       expect(doc.authors_ordered.last["sequence"]).to eq 5

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SolrDocument do
       doc = described_class.new({ id: "1", author_tesim: ["Eve Tuck", "K. Wayne Yang"] })
       expect(doc.authors_ordered.first["sequence"]).to eq 0
       expect(doc.authors_ordered.last["sequence"]).to eq 0
-      expect(doc.authors_ordered.any?{ |author| author["value"] == "Eve Tuck"}).to eq true
+      expect(doc.authors_ordered.any? { |author| author["value"] == "Eve Tuck" }).to eq true
       expect(doc.authors_ordered.count).to eq 2
     end
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe SolrDocument do
 
   describe "#authors_ordered" do
     it "handles order for PDC Describe records" do
-      pdc_describe_data = File.read(File.join(fixture_path, 'files', 'pppl1.json'))
+      pdc_describe_data = JSON.parse(File.read(File.join(fixture_path, 'files', 'pppl1.json')))
       pdc_authors = pdc_describe_data["resource"]["creators"].to_json
       doc = described_class.new({ id: "1", authors_json_ss: pdc_authors })
       expect(doc.authors_ordered.first["sequence"]).to eq 1
@@ -63,7 +63,7 @@ RSpec.describe SolrDocument do
       expect(doc.authors_ordered.count).to eq 5
     end
 
-    it "returns the authors unordered DataSpace records" do
+    it "returns the authors unordered for DataSpace records" do
       doc = described_class.new({ id: "1", author_tesim: ["Eve Tuck", "K. Wayne Yang"] })
       expect(doc.authors_ordered.first["sequence"]).to eq 0
       expect(doc.authors_ordered.last["sequence"]).to eq 0


### PR DESCRIPTION
For records coming from PDC Describe honor the author order in the search results and the show page in PDC Discovery. DataSpace records don't have an order for the authors.

In the show page we also display the ORCID along with each author when the data is available. This used to be a hard-coded feature for one researcher only and now it's data driven 🎉 

![Screenshot 2023-05-10 at 9 17 43 PM](https://github.com/pulibrary/pdc_discovery/assets/568286/e4dd5298-d236-487c-bd5b-64e72c447469)

Closes #376 