### PR TITLE
Display Globus button when Globus URI is on the the description

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -194,14 +194,13 @@ module ApplicationHelper
 
   def render_globus_download(uri, item_id)
     return if uri.nil?
+    # The `globus-download-link` CSS class is used to track download clicks in Plausible
     html = <<-HTML
     <div id="globus">
-      <button type="button" class="globus_button lux-button solid medium">
-        <a href="#{uri}" title="Opens in a new tab" class="globus-download-link"
-          target="_blank" rel="noopener noreferrer" data-item-id="#{item_id}">
-          #{image_tag('globus_logo.png', width: '20')} Download from Globus
-        </a>
-      </button>
+      <a href="#{uri}" title="Opens in a new tab" class="btn globus_button globus-download-link"
+        target="_blank" rel="noopener noreferrer" data-item-id="#{item_id}">
+        #{image_tag('globus_logo.png', width: '20', alt: 'Globus logo')} Download from Globus
+      </a>
     </div>
     HTML
     html.html_safe

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -50,6 +50,9 @@ class SolrDocument
     "interactive resource" => "bi-pc-display-horizontal"
   }.freeze
 
+  # .*?\s is lazy match so the regex stop as soon as space is found
+  GLOBUS_URI_REGEX = /.*(https\:\/\/app.globus.org\/file-manager.*?\s).*/.freeze
+
   def id
     fetch('id')
   end
@@ -216,7 +219,12 @@ class SolrDocument
     uri.each do |link|
       return link if link.downcase.start_with?('https://app.globus.org/')
     end
-    nil
+    globus_uri_from_description
+  end
+
+  def globus_uri_from_description
+    match = description&.match(GLOBUS_URI_REGEX)
+    return match.captures.first.strip if match
   end
 
   def extent

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -71,5 +71,17 @@ RSpec.describe SolrDocument do
       expect(doc.authors_ordered.count).to eq 2
     end
   end
+
+  describe "#globus_uri_from_description" do
+    it "returns nil when no Globus URI available in the description" do
+      doc = described_class.new({ id: "1", author_tesim: [] })
+      expect(doc.globus_uri_from_description).to be nil
+    end
+
+    it "returns the Globus URI when it is available in the description" do
+      doc = described_class.new({ id: "1", description_tsim: ["xxx https://app.globus.org/file-manager?origin_id=dc43f461-0ca7-4203-848c-33a9fc00a464&origin_path=%2F yyy"] })
+      expect(doc.globus_uri_from_description).to eq "https://app.globus.org/file-manager?origin_id=dc43f461-0ca7-4203-848c-33a9fc00a464&origin_path=%2F"
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe SolrDocument do
     it "returns nil when no Globus URI available in the description" do
       doc = described_class.new({ id: "1", author_tesim: [] })
       expect(doc.globus_uri_from_description).to be nil
+
+      doc = described_class.new({ id: "1", description_tsim: ["no globus URI in here"] })
+      expect(doc.globus_uri_from_description).to be nil
     end
 
     it "returns the Globus URI when it is available in the description" do


### PR DESCRIPTION
Make sure we pick up the Globus URI from the description if not it is not available as an individual URI in the metadata.

Closes #450 
