### PR TITLE
File display includes full path and excludes PDC Describe preservation files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.2.5
+  browser-tools: circleci/browser-tools@1.4.2
 
 executors:
   pdc_discovery_executor_build:

--- a/app/models/dataset_file.rb
+++ b/app/models/dataset_file.rb
@@ -2,7 +2,7 @@
 
 class DatasetFile
   attr_accessor :name, :description, :format, :size, :mime_type, :sequence, :handle, :extension,
-    :source, :download_url
+    :source, :download_url, :full_path
 
   def self.from_hash(data, data_source)
     if data_source == "pdc_describe"
@@ -16,6 +16,7 @@ class DatasetFile
     hash = data.with_indifferent_access
     file = DatasetFile.new
     file.source = "dataspace"
+    file.full_path = hash[:name]
     file.name = hash[:name]
     file.extension = File.extname(file.name)
     file.extension = file.extension[1..] if file.extension != "." # drop the leading period
@@ -34,6 +35,7 @@ class DatasetFile
     hash = data.with_indifferent_access
     file = DatasetFile.new
     file.source = "pdc_describe"
+    file.full_path = hash[:full_name]
     file.name = hash[:name]
     file.extension = File.extname(file.name)
     file.extension = file.extension[1..] if file.extension != "." # drop the leading period

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -185,7 +185,7 @@ class SolrDocument
   def files
     @files ||= begin
       data = JSON.parse(fetch("files_ss", "[]"))
-      data.map { |x| DatasetFile.from_hash(x, data_source) }.sort_by(&:sequence)
+      data.map { |file| DatasetFile.from_hash(file, data_source) }.sort_by(&:sequence)
     end
   end
 

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -28,7 +28,7 @@
                   <td>
                     <span>
                       <i class="bi bi-file-arrow-down"></i>
-                      <a href="<%= file.download_url %>" class="documents-file-link" target="_blank" title="<%= file.name %>"><%= truncate(file.name, length: 60) %></a>
+                      <a href="<%= file.download_url %>" class="documents-file-link" target="_blank" title="<%= file.full_path %>"><%= truncate(file.full_path, length: 60) %></a>
                     </span>
                   </td>
                   <% if @document.data_source == "dataspace" %>

--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -34,4 +34,21 @@ class ImportHelper
     response = HTTParty.get(solr_query)
     response.parsed_response["response"]["numFound"] != 0
   end
+
+  # Calculates the display filename for a PDC Describe file.
+  # PDC Describe files are prefixed with DOI + database_id, for example "10.123/4567/40/folder1/filename1.txt"
+  # (where 40 is the database id).
+  # This method strips the DOI and the database ID from the path so that we display a friendly
+  # path to the user, e.g. "folder1/filename1.txt".
+  def self.display_filename(full_path, doi)
+    display_filename = nil
+    if doi.present? && full_path.start_with?(doi)
+      # drop the DOI
+      filename_no_doi = full_path[doi.length..-1]
+      db_id = filename_no_doi.match(/\/\d+\//).to_s
+      # drop the database ID
+      display_filename = filename_no_doi[db_id.length..-1] unless db_id.empty?
+    end
+    display_filename || full_path
+  end
 end

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -376,17 +376,23 @@ end
 # to_field 'source_ssim', extract_xpath("/item/metadata/key[text()='dcterms.source']/../value")
 
 # ==================
-# Store all files metadata as a single JSON string so that we can display detailed information for each of them.
+# Store files metadata as a single JSON string so that we can display detailed information for each of them.
 to_field 'files_ss' do |record, accumulator, _context|
   raw_doi = record.xpath("/hash/resource/doi/text()").to_s
   files = record.xpath("/hash/files/file").map do |file|
-    {
-      name: File.basename(file.xpath("filename").text),
-      full_name: ImportHelper.display_filename(file.xpath("filename").text, raw_doi),
-      size: file.xpath("size").text,
-      url: file.xpath('url').text
-    }
-  end
+    file_name = file.xpath("filename").text
+    if file_name.include?("/princeton_data_commons/")
+      # Exclude the preservation files
+      nil
+    else
+      {
+        name: File.basename(file.xpath("filename").text),
+        full_name: ImportHelper.display_filename(file.xpath("filename").text, raw_doi),
+        size: file.xpath("size").text,
+        url: file.xpath('url').text
+      }
+    end
+  end.compact
   accumulator.concat [files.to_json.to_s]
 end
 

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -381,6 +381,7 @@ to_field 'files_ss' do |record, accumulator, _context|
   files = record.xpath("/hash/files/file").map do |file|
     {
       name: File.basename(file.xpath("filename").text),
+      full_name: file.xpath("filename").text,
       size: file.xpath("size").text,
       url: file.xpath('url').text
     }

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -378,10 +378,11 @@ end
 # ==================
 # Store all files metadata as a single JSON string so that we can display detailed information for each of them.
 to_field 'files_ss' do |record, accumulator, _context|
+  raw_doi = record.xpath("/hash/resource/doi/text()").to_s
   files = record.xpath("/hash/files/file").map do |file|
     {
       name: File.basename(file.xpath("filename").text),
-      full_name: file.xpath("filename").text,
+      full_name: ImportHelper.display_filename(file.xpath("filename").text, raw_doi),
       size: file.xpath("size").text,
       url: file.xpath('url').text
     }

--- a/spec/fixtures/files/bitklavier_binaural.json
+++ b/spec/fixtures/files/bitklavier_binaural.json
@@ -100,6 +100,11 @@
             "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file2.txt"
         },
         {
+            "filename": "10.80021/3m1k-6036/122/princeton_data_commons/datacite.xml",
+            "size": 123,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/princeton_data_commons/datacite.xml"
+        },
+        {
             "filename": "10.80021/3m1k-6036/122/folder-a/file3.txt",
             "size": 396003,
             "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/folder-a/file3.txt"

--- a/spec/fixtures/files/bitklavier_binaural.json
+++ b/spec/fixtures/files/bitklavier_binaural.json
@@ -98,6 +98,11 @@
             "filename": "10.80021/3m1k-6036/122/file2.txt",
             "size": 396003,
             "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file2.txt"
+        },
+        {
+            "filename": "10.80021/3m1k-6036/122/folder-a/file3.txt",
+            "size": 396003,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/folder-a/file3.txt"
         }
     ],
     "group": {

--- a/spec/lib/describe_indexer_spec.rb
+++ b/spec/lib/describe_indexer_spec.rb
@@ -112,6 +112,11 @@ RSpec.describe DescribeIndexer do
         expect(file3["name"]).to eq "file3.txt"
         expect(file3["full_name"]).to eq "10.80021/3m1k-6036/122/folder-a/file3.txt"
       end
+      it "excludes PDC preservation files" do
+        files = JSON.parse(indexed_record['files_ss'])
+        datacite_xml = files.find { |file| file["full_name"].include? "/princeton_data_commons/datacite.xml" }
+        expect(datacite_xml).to be nil
+      end
     end
 
     context "all text catch all field" do

--- a/spec/lib/describe_indexer_spec.rb
+++ b/spec/lib/describe_indexer_spec.rb
@@ -105,9 +105,12 @@ RSpec.describe DescribeIndexer do
         files = JSON.parse(indexed_record['files_ss'])
         file1 = files.find { |file| file["name"] == "file1.jpg" }
         file2 = files.find { |file| file["name"] == "file2.txt" }
+        file3 = files.find { |file| file["name"] == "file3.txt" }
         expect(file1["size"]).to eq "316781"
         expect(file1["url"]).to eq "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file1.jpg"
         expect(file2["size"]).to eq "396003"
+        expect(file3["name"]).to eq "file3.txt"
+        expect(file3["full_name"]).to eq "10.80021/3m1k-6036/122/folder-a/file3.txt"
       end
     end
 

--- a/spec/lib/traject/import_helper_spec.rb
+++ b/spec/lib/traject/import_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "./lib/traject/import_helper.rb"
+
+RSpec.describe ImportHelper do
+  describe "#display_filename" do
+    it "handles normal cases correctly" do
+      doi = "10.123/4567"
+      expect(described_class.display_filename("10.123/4567/40/file1.txt", doi)).to eq "file1.txt"
+      expect(described_class.display_filename("10.123/4567/40/folder1/file1.txt", doi)).to eq "folder1/file1.txt"
+    end
+
+    it "defaults to the full path DOI is not present" do
+      expect(described_class.display_filename("10.123/4567/40/file1.txt", nil)).to eq "10.123/4567/40/file1.txt"
+      expect(described_class.display_filename("10.123/4567/40/file1.txt", "")).to eq "10.123/4567/40/file1.txt"
+    end
+
+    it "defaults to full path when path does not start with the DOI" do
+      expect(described_class.display_filename("10.123/4567/40/file1.txt", "10.123/9999")).to eq "10.123/4567/40/file1.txt"
+    end
+
+    it "defaults to full path when database ID is not numeric" do
+      expect(described_class.display_filename("10.123/4567/x40/file1.txt", "10.123/4567")).to eq "10.123/4567/x40/file1.txt"
+    end
+  end
+end

--- a/spec/support/system_specs.rb
+++ b/spec/support/system_specs.rb
@@ -6,6 +6,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
+    Webdrivers::Chromedriver.required_version = "114.0.5735.90"
     if ENV["RUN_IN_BROWSER"]
       driven_by(:selenium_chrome)
     else


### PR DESCRIPTION
There are two issues addressed in this PR: 
1. We now display the path of files (e.g. "folder-a/file1.txt") rather than just the file name (e.g. "fileA.txt") for PDC Describe files.
2. We now exclude the PDC Describe preservation files from the import (e.g. "/princeton_data_commons/datacite.xml")

Displaying the path of files was a bit trickier than it sounds because the actual path to the file includes the DOI and the `database_id` of the record in PDC Describe (e.g. "10.123/456/40/folder-a/file1.txt") but we do **not** index the `database-id` ("40" in this example) into Discovery. 

The following screenshot shows how files with folders are displayed:

![Screenshot 2023-07-26 at 11 39 43 AM](https://github.com/pulibrary/pdc_discovery/assets/568286/6d6f6687-1af1-4197-979d-556f02aeb336)

Closes #455 