### PR TITLE
Disable reindex on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,7 +9,7 @@ set :branch, ENV["BRANCH"] || "main"
 set :deploy_to, "/opt/pdc_discovery"
 
 # This fixes a "Rails manifest file not found" error when deploying to a new server
-# for the first time. 
+# for the first time.
 # See https://stackoverflow.com/questions/47914115/rails-manifest-file-not-found-deploying-with-capistrano
 Rake::Task["deploy:assets:backup_manifest"].clear_actions
 Rake::Task["deploy:assets:restore_manifest"].clear_actions
@@ -25,6 +25,6 @@ namespace :pdc_discovery do
   end
 end
 
-# Uncomment to re-index on every deploy. Only needed when we're actively 
+# Uncomment to re-index on every deploy. Only needed when we're actively
 # updating how indexing happens.
-after "deploy:published", "pdc_discovery:reindex"
+# after "deploy:published", "pdc_discovery:reindex"


### PR DESCRIPTION
We do not need to reindex on every deploy anymore and it will make deployments a bit faster.

We still can manually force a reindex after a deploy if we believe we need one. The following rake task will do it:

```
bundle exec rake index:research_data
```
