### PR TITLE
ORCID and Affiliation search from popover

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -189,6 +189,14 @@ class CatalogController < ApplicationController
       }
     end
 
+    config.add_search_field('orcid') do |field|
+      field.label = "ORCID"
+      field.solr_parameters = {
+        qf: 'authors_orcid_ssim',
+        pf: 'authors_orcid_ssim'
+      }
+    end
+
     # Specifying a :qt only to show it's possible, and so our internal automated
     # tests can test it. In this case it's the same as
     # config[:default_solr_parameters][:qt], so isn't actually neccesary.

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -96,6 +96,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subcommunities_ssim', label: 'Subcommunity'
 
     config.add_facet_field 'collection_tag_ssim', label: 'Collection Tags'
+    config.add_facet_field 'authors_affiliation_ssim', label: 'Affiliation'
 
     config.add_facet_field 'genre_ssim', label: 'Type'
     config.add_facet_field 'year_available_itsi', label: 'Year Published', range: true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -280,7 +280,7 @@ module ApplicationHelper
       orcid_html = <<-HTML
         <img alt='ORCID logo' src='https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png' width='16' height='16' />
         ORCID: <a href='https://orcid.org/#{orcid}' target=_blank>#{orcid}</a><br/>
-        Find other works <a href='#{search_link_by_field(orcid)}'>by this author</a>.<br/>
+        Find other works <a href='#{search_link_by_field(orcid)}'>by this author</a> in PDC Discovery.<br/>
       HTML
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,8 +71,14 @@ module ApplicationHelper
     html.html_safe
   end
 
-  def search_link(value, field)
-    "#{subdirectory_for_links}/?f[#{field}][]=#{CGI.escape(value)}&q=&search_field=all_fields"
+  # Returns a search link to search by a facet field
+  def search_link(value, facet_field)
+    "#{subdirectory_for_links}/?f[#{facet_field}][]=#{CGI.escape(value)}&q=&search_field=all_fields"
+  end
+
+  # Returns a search link to search by a specific field
+  def search_link_by_field(value, field = "")
+    "#{subdirectory_for_links}/?&q=#{CGI.escape(value)}&search_field=#{field}"
   end
 
   # Outputs the HTML to render a single value as an HTML table row with a search link
@@ -274,10 +280,17 @@ module ApplicationHelper
       orcid_html = <<-HTML
         <img alt='ORCID logo' src='https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png' width='16' height='16' />
         ORCID: <a href='https://orcid.org/#{orcid}' target=_blank>#{orcid}</a><br/>
+        <br/>
+        Find other works <a href='#{search_link_by_field(orcid)}'>by this author</a>.<br/>
       HTML
     end
 
-    affiliation_html = author.affiliation_name ? author.affiliation_name + '<br/>' : ""
+    affiliation_html = ""
+    if author.affiliation_name
+      affiliation_html = <<-HTML
+        <a href='#{search_link(author.affiliation_name, "authors_affiliation_ssim")}'>#{author.affiliation_name}</a><br/>
+      HTML
+    end
 
     "#{orcid_html}#{affiliation_html}"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -286,8 +286,9 @@ module ApplicationHelper
 
     affiliation_html = ""
     if author.affiliation_name
+      affiliation_link = search_link(author.affiliation_name, "authors_affiliation_ssim")
       affiliation_html = <<-HTML
-        <a href='#{search_link(author.affiliation_name, "authors_affiliation_ssim")}'>#{author.affiliation_name}</a><br/>
+        <a href='#{affiliation_link}'>#{author.affiliation_name}</a><br/>
       HTML
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -280,7 +280,6 @@ module ApplicationHelper
       orcid_html = <<-HTML
         <img alt='ORCID logo' src='https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png' width='16' height='16' />
         ORCID: <a href='https://orcid.org/#{orcid}' target=_blank>#{orcid}</a><br/>
-        <br/>
         Find other works <a href='#{search_link_by_field(orcid)}'>by this author</a>.<br/>
       HTML
     end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -15,4 +15,10 @@ class Author
   def affiliation_name
     @affiliation&.fetch("value", nil)
   end
+
+  def orcid
+    if @identifier&.dig("scheme") == "ORCID"
+      @identifier&.dig("value")
+    end
+  end
 end

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -11,6 +11,14 @@
     overflow: hidden;
   }
 
+  /*
+   * Allow the popover area to stretch wide
+   * Source: https://stackoverflow.com/a/22459917/446681
+   */
+  .popover{
+    max-width: 100%;
+  }
+
   .author_popover_link {
     text-decoration-line: underline;
     text-decoration-style: dashed;

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -114,7 +114,6 @@ to_field 'authors_affiliation_ssim' do |record, accumulator, _c|
   pdc_json = record.xpath("/hash/pdc_describe_json/text()").first.content
   authors_json = JSON.parse(pdc_json).dig("resource", "creators") || []
   affiliations = authors_json.map { |author| Author.new(author).affiliation_name }
-  puts affiliations.compact.uniq
   accumulator.concat affiliations.compact.uniq
 end
 

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -107,7 +107,15 @@ to_field 'authors_orcid_ssim' do |record, accumulator, _c|
   pdc_json = record.xpath("/hash/pdc_describe_json/text()").first.content
   authors_json = JSON.parse(pdc_json).dig("resource", "creators") || []
   orcids = authors_json.map { |author| Author.new(author).orcid }
-  accumulator.concat orcids
+  accumulator.concat orcids.compact.uniq
+end
+
+to_field 'authors_affiliation_ssim' do |record, accumulator, _c|
+  pdc_json = record.xpath("/hash/pdc_describe_json/text()").first.content
+  authors_json = JSON.parse(pdc_json).dig("resource", "creators") || []
+  affiliations = authors_json.map { |author| Author.new(author).affiliation_name }
+  puts affiliations.compact.uniq
+  accumulator.concat affiliations.compact.uniq
 end
 
 # ==================

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -103,6 +103,13 @@ to_field 'authors_json_ss' do |record, accumulator, _c|
   accumulator.concat [authors.to_json]
 end
 
+to_field 'authors_orcid_ssim' do |record, accumulator, _c|
+  pdc_json = record.xpath("/hash/pdc_describe_json/text()").first.content
+  authors_json = JSON.parse(pdc_json).dig("resource", "creators") || []
+  orcids = authors_json.map { |author| Author.new(author).orcid }
+  accumulator.concat orcids
+end
+
 # ==================
 # title fields
 to_field 'title_tesim' do |record, accumulator, _c|

--- a/spec/system/bitklavier_single_item_metadata_spec.rb
+++ b/spec/system/bitklavier_single_item_metadata_spec.rb
@@ -33,7 +33,7 @@ describe 'PDC Describe Bitklavier Single item page', type: :system, js: true do
     author_top_of_page = '<span class="author-name">'
     author_popover_title = 'data-original-title="Trueman, Daniel"'
     author_popover_orcid = 'https://orcid.org/1234-1234-1234-1234'
-    author_popover_affiliation = "target=_blank>1234-1234-1234-1234</a><br/>\nPrinceton Plasma Physics Laboratory<br/>"
+    author_popover_affiliation = "<a href='/?f[authors_affiliation_ssim][]=Princeton+Plasma+Physics+Laboratory&amp;q=&amp;search_field=all_fields'>Princeton Plasma Physics Laboratory</a><br/>"
     author_meta = 'Trueman, Daniel (Princeton Plasma Physics Laboratory)'
     expect(page.html.include?(author_top_of_page)).to be true
     expect(page.html.include?(author_popover_title)).to be true


### PR DESCRIPTION
Index author's ORCID and Affiliation information, show this information in the author popover, and make it searchable.

## Popover with search links
![Screenshot 2023-08-11 at 11 49 26 AM](https://github.com/pulibrary/pdc_discovery/assets/568286/5039198a-cbb2-4bc8-ba1a-fdcf466edf7b)

## Search by ORCID
![Screenshot 2023-08-11 at 11 49 35 AM](https://github.com/pulibrary/pdc_discovery/assets/568286/e1ae9141-4ef6-40f3-b8ae-ce6029f202d3)

Closes #392 