### PR TITLE
Related identifiers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,60 +110,6 @@ module ApplicationHelper
     html.html_safe
   end
 
-  # Outputs the HTML to render a single value as an HTML table row
-  # to be displayed on the sidebar.
-  def render_sidebar_row(title, value)
-    return if value.nil?
-    html = <<-HTML
-    <tr>
-      <th scope="row" class="sidebar-label"><span>#{title}</span></th>
-      <td class="sidebar-value"><span>#{html_escape(value)}</span></td>
-    </tr>
-    HTML
-    html.html_safe
-  end
-
-  # Outputs the HTML to render the DOI as an HTML table row to be
-  # displayed on the sidebar with a copy to clipboard button next to it.
-  def render_sidebar_doi_row(url, value)
-    return if url.nil?
-    tooltip = "Copy DOI URL to the clipboard"
-    html = <<-HTML
-    <tr>
-      <th scope="row" class="sidebar-label"><span>DOI:</span></th>
-      <td class="sidebar-value">
-        <span>#{link_to(value, url, target: '_blank', rel: 'noopener noreferrer')}</span>
-        <button id="copy-doi" class="btn btn-sm" data-url="#{url}" title="#{tooltip}">
-          <i id="copy-doi-icon" class="bi bi-clipboard" title="#{tooltip}"></i>
-          <span id="copy-doi-label" class="copy-doi-label-normal">COPY</span>
-        </button>
-      </td>
-    </tr>
-    HTML
-    html.html_safe
-  end
-
-  def render_sidebar_licenses(licenses)
-    return if licenses.count.zero?
-
-    licenses_html = licenses.map do |license|
-      url = License.url(license)
-      if url.nil?
-        "<span>#{html_escape(license)}</span>"
-      else
-        "<span>" + link_to(license, url, target: '_blank', rel: 'noopener noreferrer') + "</span>"
-      end
-    end
-
-    html = <<-HTML
-    <tr>
-      <th scope="row" class="sidebar-label"><span>#{'License'.pluralize(licenses.count)}:</span></th>
-      <td class="sidebar-value">#{licenses_html.join('<br/>')}</td>
-    </tr>
-    HTML
-    html.html_safe
-  end
-
   # Renders citation information APA-ish and BibTeX.
   # Notice that the only the APA style is visible, the BibTeX citataion is enabled via JavaScript.
   def render_cite_as(document)
@@ -193,24 +139,6 @@ module ApplicationHelper
           <span class="copy-citation-label-normal">DOWNLOAD</span>
         </button>
       </div>
-    HTML
-    html.html_safe
-  end
-
-  # Outputs the HTML to render a list of subjects
-  # (this is used on the sidebar)
-  def render_subject_search_links(title, values, field)
-    return if values.count.zero?
-    # Must use <divs> instead of <spans> for them to wrap inside the sidebar
-    links_html = values.map do |value|
-      "#{link_to(value, search_link(value, field), class: 'badge badge-dark sidebar-value-badge', title: value)}<br/>"
-    end
-
-    html = <<-HTML
-    <tr>
-      <th scope="row" class="sidebar-label"><span>#{title}: </span></th>
-      <td>#{links_html.join(' ')}</td>
-    </tr>
     HTML
     html.html_safe
   end

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# rubocop:disable Rails/OutputSafety
+module SidebarHelper
+  # Outputs the HTML to render the DOI with a copy to clipboard button next to it.
+  def render_sidebar_doi_row(url, value)
+    return if url.nil?
+    tooltip = "Copy DOI URL to the clipboard"
+    html = <<-HTML
+      <span class="sidebar-header">DOI</span><br/>
+      <span class="sidebar-value">#{link_to(value, url, target: '_blank', rel: 'noopener noreferrer')}</span>
+        <button id="copy-doi" style="padding-top: 0;" class="btn btn-sm" data-url="#{url}" title="#{tooltip}">
+          <i id="copy-doi-icon" class="bi bi-clipboard" title="#{tooltip}"></i>
+          <span id="copy-doi-label" class="copy-doi-label-normal">COPY</span>
+        </button>
+    HTML
+    html.html_safe
+  end
+
+  def render_sidebar_licenses(licenses)
+    return if licenses.count.zero?
+
+    licenses_html = licenses.map do |license|
+      url = License.url(license)
+      if url.nil?
+        "<span>#{html_escape(license)}</span>"
+      else
+        "<span>" + link_to(license, url, target: '_blank', rel: 'noopener noreferrer') + "</span>"
+      end
+    end
+
+    html = <<-HTML
+    <tr>
+      <th scope="row" class="sidebar-label"><span>#{'License'.pluralize(licenses.count)}:</span></th>
+      <td class="sidebar-value">#{licenses_html.join('<br/>')}</td>
+    </tr>
+    HTML
+    html.html_safe
+  end
+
+  # Outputs the HTML to render a list of subjects
+  def render_sidebar_subject_search_links(header, values, field)
+    return if values.count.zero?
+
+    links_html = values.map do |value|
+      link_to(value, search_link(value, field), class: 'badge badge-dark sidebar-value-badge', title: value)
+    end.join(" ")
+
+    html = <<-HTML
+      <div class="sidebar-row">
+        <span class="sidebar-header">#{header}</span><br/>
+        <span class="sidebar-value">#{links_html}</span>
+      </div>
+    HTML
+    html.html_safe
+  end
+
+  def render_sidebar_value(header, value)
+    return if value.nil?
+    html = <<-HTML
+      <div class="sidebar-row">
+        <span class="sidebar-header">#{header}</span><br/>
+        <span class="sidebar-value">#{value}</span>
+      </div>
+    HTML
+    html.html_safe
+  end
+
+  def render_sidebar_values(header, values, separator = "<br/>")
+    return if values.count == 0
+    html = <<-HTML
+      <div class="sidebar-row">
+        <span class="sidebar-header">#{header}</span><br/>
+        <span class="sidebar-value">#{values.join(separator)}</span>
+      </div>
+    HTML
+    html.html_safe
+  end
+
+  def render_sidebar_related_identifiers(header, identifiers)
+    return if identifiers.count == 0
+
+    identifiers_html = identifiers.map do |identifier|
+      id = identifier["related_identifier"]
+      type = identifier["relation_type"]&.titleize
+      if url.start_with?("https://", "http://")
+        "#{type} <a href=#{id} target=_blank>#{id}</a>"
+      else
+        "#{type} #{id}"
+      end
+    end.join("<br/>")
+
+    html = <<-HTML
+      <div class="sidebar-row">
+        <span class="sidebar-header">#{header}</span><br/>
+        <span class="sidebar-value">#{identifiers_html}</span>
+      </div>
+    HTML
+    html.html_safe
+  end
+end
+# rubocop:enable Rails/OutputSafety

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -182,6 +182,10 @@ class SolrDocument
     fetch("data_source_ssi", "dataspace")
   end
 
+  def pdc_describe_record?
+    data_source == "pdc_describe"
+  end
+
   def files
     @files ||= begin
       data = JSON.parse(fetch("files_ss", "[]"))
@@ -270,6 +274,13 @@ class SolrDocument
     fetch("publisher_corporate_ssim", [])
   end
 
+  def related_identifiers
+    @related_identifiers ||= begin
+      hash = JSON.parse(fetch("pdc_describe_json_ss", "{}"))
+      hash.dig("resource", "related_objects") || []
+    end
+  end
+
   def relation
     fetch("relation_ssim", [])
   end
@@ -352,7 +363,11 @@ class SolrDocument
   end
 
   def subject
-    fetch("subject_tesim", [])
+    if pdc_describe_record?
+      fetch("subject_all_ssim", [])
+    else
+      fetch("subject_tesim", [])
+    end
   end
 
   def subject_classification

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -6,11 +6,10 @@
 </div>
 
 <div id="sidebar-keywords" class="sidebar">
-  <table id="sidebar-table">
-    <%= render_sidebar_licenses @document.license %>
-    <%= render_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
-    <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
-    <%= render_sidebar_row "File Types: ", file_counts.join(", ") %>
-    <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>
-  </table>
+  <%= render_sidebar_licenses @document.license %>
+  <%= render_sidebar_subject_search_links "Keywords", @document.subject, "subject_all_ssim" %>
+  <% file_counts = @document.file_counts.map { |group| "#{group[:extension]}(#{group[:file_count]})" } %>
+  <%= render_sidebar_values "File Types: ", file_counts, ", " %>
+  <%= render_sidebar_doi_row @document.doi_url, @document.doi_value %>
+  <%= render_sidebar_related_identifiers "Related Identifiers", @document.related_identifiers %>
 </div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -15,13 +15,21 @@
    * Allow the popover area to stretch wide
    * Source: https://stackoverflow.com/a/22459917/446681
    */
-  .popover{
+  .popover {
     max-width: 100%;
   }
 
   .author_popover_link {
     text-decoration-line: underline;
     text-decoration-style: dashed;
+  }
+
+  .sidebar-header {
+    font-weight: bold;
+  }
+
+  .sidebar-value {
+    margin-left: 20px;
   }
 </style>
 <% @page_title = "#{@document.title} || 'untitled'" %>

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 # rubocop:disable RSpec/ExampleLength
 RSpec.describe SolrDocument do
   describe "#authors_et_al" do
@@ -113,4 +114,5 @@ RSpec.describe SolrDocument do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength
 # rubocop:enable RSpec/ExampleLength

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -100,5 +100,17 @@ RSpec.describe SolrDocument do
       expect(doc.globus_uri_from_description).to eq "https://app.globus.org/file-manager?origin_id=dc43f461-0ca7-4203-848c-33a9fc00a464&origin_path=%2F"
     end
   end
+
+  describe "#subjects" do
+    it "returns the values for PDC Describe records" do
+      doc = described_class.new({ id: "1", data_source_ssi: "pdc_describe", subject_all_ssim: ["subject1", "subject2"] })
+      expect(doc.subject.sort).to eq ["subject1", "subject2"]
+    end
+
+    it "returns the values for DataSpace records" do
+      doc = described_class.new({ id: "1", subject_tesim: ["subject1", "subject2"] })
+      expect(doc.subject.sort).to eq ["subject1", "subject2"]
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
Displays the Related Identifiers (for PDC Describe records) in the sidebar

![Screenshot 2023-08-14 at 2 17 13 PM](https://github.com/pulibrary/pdc_discovery/assets/568286/0366dd28-5f63-4f32-8ee6-e7f6bbc62a21)

In the process of implementing this functionality I refactored the helpers for the sidebar to their own file and fixed a bug in the display of keywords (aka subjects). We were not taking into account the new field for this data for PDC Describe records.

Closes #349 