### PR TITLE
Remove MaRC boilerplate bc we do not use MaRC

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -3,12 +3,6 @@
 # rubocop:disable Metrics/ClassLength
 class SolrDocument
   include Blacklight::Solr::Document
-  # The following shows how to setup this blacklight document to display marc documents
-  extension_parameters[:marc_source_field] = :marc_ss
-  extension_parameters[:marc_format_type] = :marcxml
-  use_extension(Blacklight::Solr::Document::Marc) do |document|
-    document.key?(SolrDocument.extension_parameters[:marc_source_field])
-  end
 
   field_semantics.merge!(
     title: 'title_tesim',


### PR DESCRIPTION
Removing this to fix deploy error: 

```
      Notifying Honeybadger of deploy.
      01 RAILS_ENV=staging bundle exec honeybadger deploy --environment staging --revision 896d86a51b470e5cc847275b6aba060eb10c4375 --repository…
      01 !! --- Honeybadger command failed --------------------------------------------- !!
      01
      01 # What did you try to do?
      01
      01   You tried to execute the following command:
      01   `honeybadger deploy --environment staging --revision 896d86a51b470e5cc847275b6aba060eb10c4375 --repository https://github.com/pulibra…
      01
      01 # What actually happend?
      01
      01   We encountered a Ruby exception and were forced to cancel your request.
      01
      01 # Error details
      01
      01   NameError: uninitialized constant Blacklight::Solr::Document::Marc
      01
      01   use_extension(Blacklight::Solr::Document::Marc) do |document|
```