### PR TITLE
Links in author pop over

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -251,10 +251,10 @@
     // https://getbootstrap.com/docs/4.6/components/popovers/
     // https://getbootstrap.com/docs/4.6/components/popovers/#dismiss-on-next-click
     //
-    // Delay is used to delay the closing of the pop over when clicking on links inside of it.
-    // The delay allows the link to recognize the click and open the corresponding URL before
-    // closing. Otherwise, sometimes the pop up closes before the link has a chance to open
-    // (see https://stackoverflow.com/questions/27012667/link-in-bootstrap-popover-doesnt-work)
+    // Delay is used to allow the popover to recognize and process the click event on links
+    // inside of it (e.g. the link to the author's ORCID). Without the delay sometimes the
+    // popover will close _before_ it opens the link clicked. For more information see
+    // https://stackoverflow.com/questions/27012667/link-in-bootstrap-popover-doesnt-work
     $('[data-toggle="popover"]').popover({
       trigger: 'focus',
       delay: { hide: 200 }

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -250,7 +250,15 @@
     // Enable the popover functionality for authors
     // https://getbootstrap.com/docs/4.6/components/popovers/
     // https://getbootstrap.com/docs/4.6/components/popovers/#dismiss-on-next-click
-    $('[data-toggle="popover"]').popover({ trigger: 'focus'});
+    //
+    // Delay is used to delay the closing of the pop over when clicking on links inside of it.
+    // The delay allows the link to recognize the click and open the corresponding URL before
+    // closing. Otherwise, sometimes the pop up closes before the link has a chance to open
+    // (see https://stackoverflow.com/questions/27012667/link-in-bootstrap-popover-doesnt-work)
+    $('[data-toggle="popover"]').popover({
+      trigger: 'focus',
+      delay: { hide: 200 }
+    });
   });
 
 </script>


### PR DESCRIPTION
Delay the closing of the pop over by a few milliseconds. This allows the links inside the pop over to recognize click on them and open the proper page *before* closing the pop over.

Attempt at fixing #487 