### PR TITLE
Ensuring that Solr requests are retransmitted should the Blacklight::Exceptions::ECONNREFUSED error be raised

### DIFF
--- a/app/views/errors/network_error.html.erb
+++ b/app/views/errors/network_error.html.erb
@@ -1,0 +1,3 @@
+<h1>We Apologize</h1>
+<p>Currently the discovery service is suffering from partially degraded network service. RDSS has been alerted to this, and shall be working to diagnose and resolve these issues promptly.</p>
+<p>We recommend that one please try once again to search <a href="/">on the front page</a> or perform the search in the search bar.</p>


### PR DESCRIPTION
Advances #491 