### PR TITLE
Adding indexing support for embargo dates parsed from PDC Describe Works

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link application.css
 
 //= link application.js

--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -40,3 +40,16 @@
 .description-container {
   padding-left: 0px;
 }
+
+.document {
+  &-embargo {
+    &-heading {
+      text-align: center;
+      .badge {
+        background-color: #ffecbd;
+        color: #705000;
+        border-color: transparent;
+      }
+    }
+  }
+}

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -5,7 +5,7 @@
 
         <!-- Only render file download table if there are files in DataSpace -->
 
-        <% if @document.files.empty? %>
+        <% if @document.embargoed? || @document.files.empty? %>
           <%= render_empty_files %>
         <% else %>
           <table id="files-table" class="table">

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -48,14 +48,21 @@
         <% end %>
       </div>
     </header>
-
+    <% if @document.embargoed? %>
+      <header class="documentHeader row">
+        <div class="col-sm-12">
+          <div class="document-embargo-heading col">
+            <span class="badge"><%= t('document.embargo_heading', embargo_date: @document.embargo_date) %></span>
+          </div>
+        </div>
+      </header>
+    <% end %>
     <div class="lux">
       <% if @document.issued_date.present? %>
         <div class="issue-date-heading">
           Issue date: <%= @document.issued_date %>
         </div>
       <% end %>
-
       <div class="document-citation">
         <header>Cite as:
           <button id="show-apa-citation-button" type='button' class='cite-as-button btn btn-primary btn-xsm' title='Show citation'>Text</button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,5 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  document:
+    embargo_heading: "File(s) associated with this object are embargoed until %{embargo_date}."

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -62,4 +62,17 @@ namespace :index do
     puts "Solr updated: #{SolrCloudHelper.update_solr_alias!}"
     Rake::Task['index:print_solr_urls'].invoke
   end
+
+  desc 'Index fixture data'
+  task fixtures: :environment do
+    indexer = DescribeIndexer.new
+
+    fixture_names = ['pdc_describe_active_embargo.json', 'pdc_describe_expired_embargo.json']
+    fixture_names.each do |fixture_name|
+      fixture_path = Rails.root.join("spec", "fixtures", "files", fixture_name)
+      fixture_json = File.read(fixture_path)
+      indexer.index_one(fixture_json)
+    end
+    SolrCloudHelper.collection_writer_commit!
+  end
 end

--- a/lib/traject/pdc_describe_indexing_config.rb
+++ b/lib/traject/pdc_describe_indexing_config.rb
@@ -181,6 +181,11 @@ to_field 'funders_ss' do |record, accumulator, _context|
 end
 
 # ==================
+# Embargo Date
+# Store and index the embargo date from the PDC Describe Work as a single value
+to_field 'embargo_date_dtsi', extract_xpath("/hash/embargo-date")
+
+# ==================
 # Store files metadata as a single JSON string so that we can display detailed information for each of them.
 to_field 'files_ss' do |record, accumulator, _context|
   raw_doi = record.xpath("/hash/resource/doi/text()").to_s

--- a/spec/fixtures/files/pdc_describe_active_embargo.json
+++ b/spec/fixtures/files/pdc_describe_active_embargo.json
@@ -1,0 +1,111 @@
+{
+    "resource": {
+        "titles": [
+            {
+                "title": "bitKlavier Grand Sample Library—Binaural Mic Image",
+                "title_type": null
+            },
+            {
+                "title": "alter title for bitKlavier (Active Embargo)",
+                "title_type": "AlternativeTitle"
+            }
+        ],
+        "description": "The bitKlavier Grand consists of sample collections of a new Steinway D grand piano from nine different stereo mic images, with: 16 velocity layers, at every minor 3rd (starting at A0); Hammer release samples; Release resonance samples; Pedal samples. Release packages at 96k/24bit, 88.2k/24bit, 48k/24bit, 44.1k/16bit are available for various applications.\r\n  Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnidirectional microphones within the piano. The bar is placed across the harp near the hammers and provides a low string / high string player’s perspective. It also produces a close sound without room or lid interactions. It can be panned across an artificial stereophonic perspective effectively in post-production. File Naming Convention: C4 = middle C. Main note names: [note name][octave]v[velocity].wav -- e.g., “D#5v13.wav”. Release resonance notes: harm[note name][octave]v[velocity].wav -- e.g., “harmC2v2.wav”. Hammer samples: rel[1-88].wav (one per key) -- e.g., “rel23.wav”. Pedal samples: pedal[D/U][velocity].wav -- e.g., “pedalU2.wav” =\u003e pedal release (U = up), velocity = 2 (quicker release than velocity = 1).\r\n  This dataset is too large to download directly from this item page. You can access and download the data via Globus (See https://www.youtube.com/watch?v=uf2c7Y1fiFs for instructions on how to use Globus).",
+        "collection_tags": [
+            "Humanities",
+            "Something else"
+        ],
+        "creators": [
+            {
+                "value": "Trueman, Daniel",
+                "name_type": "Personal",
+                "given_name": "Daniel",
+                "family_name": "Trueman",
+                "identifier": {
+                    "value": "1234-1234-1234-1234",
+                    "scheme": "ORCID",
+                    "scheme_uri": "https://orcid.org"
+                },
+                "affiliations": [
+                    {
+                        "value": "Princeton Plasma Physics Laboratory",
+                        "identifier": "https://ror.org/03vn1ts68",
+                        "scheme": "ROR",
+                        "scheme_uri": null
+                    }
+                ],
+                "sequence": 1
+            }
+        ],
+        "resource_type": "Dataset",
+        "resource_type_general": "Dataset",
+        "publisher": "Princeton University",
+        "publication_year": "2021",
+        "ark": "ark:/88435/dsp015999n653h",
+        "doi": "10.34770/r75s-9j74-active-embargo",
+        "rights": {
+            "identifier": "GPLv3",
+            "uri": "https://www.gnu.org/licenses/gpl-3.0.en.html",
+            "name": "GNU General Public License"
+        },
+        "version_number": "1",
+        "related_objects": [],
+        "keywords": [
+            "keyword1",
+            "keyword2",
+            "keyword3"
+        ],
+        "contributors": [
+            {
+                "value": "Villalta, Andrés",
+                "name_type": "Personal",
+                "given_name": "Andrés",
+                "family_name": "Villalta",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Chou, Katie",
+                "name_type": "Personal",
+                "given_name": "Katie",
+                "family_name": "Chou",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Ayres, Christien",
+                "name_type": "Personal",
+                "given_name": "Christien",
+                "family_name": "Ayres",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Wang, Matthew",
+                "name_type": "Personal",
+                "given_name": "Matthew",
+                "family_name": "Wang",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 1,
+                "type": "CONTACT_PERSON"
+            }
+        ],
+        "funders": []
+    },
+    "embargo_date": "2033-09-13T00:00:00Z",
+    "files": [],
+    "group": {
+        "title": "Research Data",
+        "description": null,
+        "code": "RD",
+        "created_at": "2023-01-05T11:26:07.005-05:00",
+        "updated_at": "2023-01-05T11:26:07.005-05:00"
+    }
+}

--- a/spec/fixtures/files/pdc_describe_expired_embargo.json
+++ b/spec/fixtures/files/pdc_describe_expired_embargo.json
@@ -1,0 +1,132 @@
+{
+    "resource": {
+        "titles": [
+            {
+                "title": "bitKlavier Grand Sample Library—Binaural Mic Image",
+                "title_type": null
+            },
+            {
+                "title": "alter title for bitKlavier (Expired Embargo)",
+                "title_type": "AlternativeTitle"
+            }
+        ],
+        "description": "The bitKlavier Grand consists of sample collections of a new Steinway D grand piano from nine different stereo mic images, with: 16 velocity layers, at every minor 3rd (starting at A0); Hammer release samples; Release resonance samples; Pedal samples. Release packages at 96k/24bit, 88.2k/24bit, 48k/24bit, 44.1k/16bit are available for various applications.\r\n  Piano Bar: Earthworks—omni-directionals. This microphone system suspends omnidirectional microphones within the piano. The bar is placed across the harp near the hammers and provides a low string / high string player’s perspective. It also produces a close sound without room or lid interactions. It can be panned across an artificial stereophonic perspective effectively in post-production. File Naming Convention: C4 = middle C. Main note names: [note name][octave]v[velocity].wav -- e.g., “D#5v13.wav”. Release resonance notes: harm[note name][octave]v[velocity].wav -- e.g., “harmC2v2.wav”. Hammer samples: rel[1-88].wav (one per key) -- e.g., “rel23.wav”. Pedal samples: pedal[D/U][velocity].wav -- e.g., “pedalU2.wav” =\u003e pedal release (U = up), velocity = 2 (quicker release than velocity = 1).\r\n  This dataset is too large to download directly from this item page. You can access and download the data via Globus (See https://www.youtube.com/watch?v=uf2c7Y1fiFs for instructions on how to use Globus).",
+        "collection_tags": [
+            "Humanities",
+            "Something else"
+        ],
+        "creators": [
+            {
+                "value": "Trueman, Daniel",
+                "name_type": "Personal",
+                "given_name": "Daniel",
+                "family_name": "Trueman",
+                "identifier": {
+                    "value": "1234-1234-1234-1234",
+                    "scheme": "ORCID",
+                    "scheme_uri": "https://orcid.org"
+                },
+                "affiliations": [
+                    {
+                        "value": "Princeton Plasma Physics Laboratory",
+                        "identifier": "https://ror.org/03vn1ts68",
+                        "scheme": "ROR",
+                        "scheme_uri": null
+                    }
+                ],
+                "sequence": 1
+            }
+        ],
+        "resource_type": "Dataset",
+        "resource_type_general": "Dataset",
+        "publisher": "Princeton University",
+        "publication_year": "2021",
+        "ark": "ark:/88435/dsp015999n653h",
+        "doi": "10.34770/r75s-9j74-expired-embargo",
+        "rights": {
+            "identifier": "GPLv3",
+            "uri": "https://www.gnu.org/licenses/gpl-3.0.en.html",
+            "name": "GNU General Public License"
+        },
+        "version_number": "1",
+        "related_objects": [],
+        "keywords": [
+            "keyword1",
+            "keyword2",
+            "keyword3"
+        ],
+        "contributors": [
+            {
+                "value": "Villalta, Andrés",
+                "name_type": "Personal",
+                "given_name": "Andrés",
+                "family_name": "Villalta",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Chou, Katie",
+                "name_type": "Personal",
+                "given_name": "Katie",
+                "family_name": "Chou",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Ayres, Christien",
+                "name_type": "Personal",
+                "given_name": "Christien",
+                "family_name": "Ayres",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 0,
+                "type": "CONTACT_PERSON"
+            },
+            {
+                "value": "Wang, Matthew",
+                "name_type": "Personal",
+                "given_name": "Matthew",
+                "family_name": "Wang",
+                "identifier": null,
+                "affiliations": [],
+                "sequence": 1,
+                "type": "CONTACT_PERSON"
+            }
+        ],
+        "funders": []
+    },
+    "embargo_date": "1970-01-01T00:00:00Z",
+    "files": [
+        {
+            "filename": "10.80021/3m1k-6036/122/file1.jpg",
+            "size": 316781,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file1.jpg"
+        },
+        {
+            "filename": "10.80021/3m1k-6036/122/file2.txt",
+            "size": 396003,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/file2.txt"
+        },
+        {
+            "filename": "10.80021/3m1k-6036/122/princeton_data_commons/datacite.xml",
+            "size": 123,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/princeton_data_commons/datacite.xml"
+        },
+        {
+            "filename": "10.80021/3m1k-6036/122/folder-a/file3.txt",
+            "size": 396003,
+            "url": "https://g-5beea4.90d4e.bd7c.data.globus.org/pdc-describe-staging-postcuration/10.80021/3m1k-6036/122/folder-a/file3.txt"
+        }
+    ],
+    "group": {
+        "title": "Research Data",
+        "description": null,
+        "code": "RD",
+        "created_at": "2023-01-05T11:26:07.005-05:00",
+        "updated_at": "2023-01-05T11:26:07.005-05:00"
+    }
+}

--- a/spec/lib/describe_indexer_spec.rb
+++ b/spec/lib/describe_indexer_spec.rb
@@ -173,6 +173,97 @@ RSpec.describe DescribeIndexer do
         response = Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
         expect(response["response"]["numFound"]).to eq 2
       end
+
+      context "when there are items which are under active embargo" do
+        let(:item_file_fixture) { file_fixture("pdc_describe_active_embargo.json") }
+        let(:embargo_resource) { item_file_fixture.read }
+        # This redundancy is required for consistent testing
+        let(:rss_feed) { file_fixture("works.rss").read }
+        let(:rss_url) { "https://pdc-describe-prod.princeton.edu/describe/works.rss" }
+        let(:indexer) do
+          described_class.new(rss_url: rss_url)
+        end
+        let(:solr_response) do
+          Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+        end
+        let(:response) { solr_response["response"] }
+        let(:num_found) { response["numFound"] }
+        let(:docs) { response["docs"] }
+        let(:doc) { docs.first }
+        let(:files) do
+          values = doc["files_ss"]
+          JSON.parse(values)
+        end
+
+        before do
+          stub_request(:get, rss_url)
+            .to_return(status: 200, body: rss_feed, headers: {})
+          stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/6.json")
+            .to_return(status: 200, body: embargo_resource, headers: {})
+          stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/20.json")
+            .to_return(status: 200, body: embargo_resource, headers: {})
+
+          Rails.configuration.pdc_discovery.index_pdc_describe = true
+          indexer.index
+        end
+
+        it "indexes the embargo date" do
+          expect(solr_response).to include("response")
+          expect(response).to include("numFound")
+          expect(num_found).to eq 1
+          expect(docs).not_to be_empty
+          expect(doc).to include("embargo_date_dtsi")
+        end
+
+        it "does not index the files" do
+          expect(solr_response).to include("response")
+          expect(response).to include("numFound")
+          expect(num_found).to eq 1
+          expect(docs).not_to be_empty
+          expect(doc).to include("files_ss")
+          expect(files).to be_empty
+        end
+      end
+
+      context "when there are items which are under active embargo" do
+        let(:item_file_fixture) { file_fixture("pdc_describe_expired_embargo.json") }
+        let(:embargo_resource) { item_file_fixture.read }
+        # This redundancy is required for consistent testing
+        let(:rss_feed) { file_fixture("works.rss").read }
+        let(:rss_url) { "https://pdc-describe-prod.princeton.edu/describe/works.rss" }
+        let(:indexer) do
+          described_class.new(rss_url: rss_url)
+        end
+        let(:solr_response) do
+          Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+        end
+        let(:response) { solr_response["response"] }
+        let(:num_found) { response["numFound"] }
+        let(:docs) { response["docs"] }
+        let(:doc) { docs.first }
+        let(:files) { doc["files_ss"] }
+
+        before do
+          stub_request(:get, rss_url)
+            .to_return(status: 200, body: rss_feed, headers: {})
+          stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/6.json")
+            .to_return(status: 200, body: embargo_resource, headers: {})
+          stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/20.json")
+            .to_return(status: 200, body: embargo_resource, headers: {})
+
+          Rails.configuration.pdc_discovery.index_pdc_describe = true
+          indexer.index
+        end
+
+        it "does indexes the files" do
+          expect(solr_response).to include("response")
+          expect(response).to include("numFound")
+          expect(num_found).to eq 1
+          expect(docs).not_to be_empty
+          expect(doc).to include("files_ss")
+          expect(files).not_to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/system/embargoed_document_spec.rb
+++ b/spec/system/embargoed_document_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe 'Embargoed Document page', type: :system, js: true do
+  context "when the Solr Document has an embargo date" do
+    # This redundancy is required for consistent testing
+    let(:embargo_resource) { item_file_fixture.read }
+    let(:rss_feed) { file_fixture("works.rss").read }
+    let(:rss_url) { "https://pdc-describe-prod.princeton.edu/describe/works.rss" }
+    let(:indexer) { DescribeIndexer.new(rss_url: rss_url) }
+    let(:solr_response) do
+      Blacklight.default_index.connection.get 'select', params: { q: '*:*' }
+    end
+
+    before do
+      stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works.rss")
+        .to_return(status: 200, body: rss_feed, headers: {})
+      stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/6.json")
+        .to_return(status: 200, body: embargo_resource, headers: {})
+      stub_request(:get, "https://pdc-describe-prod.princeton.edu/describe/works/20.json")
+        .to_return(status: 200, body: embargo_resource, headers: {})
+
+      Blacklight.default_index.connection.delete_by_query("*:*")
+      Blacklight.default_index.connection.commit
+      indexer.index
+    end
+
+    context "and the PDC Describe Work is under active embargo" do
+      let(:document_id) { "doi-10-34770-r75s-9j74-active-embargo" }
+      let(:item_file_fixture) { file_fixture("pdc_describe_active_embargo.json") }
+      it "renders a message to the client expressing this and detailing the embargo date" do
+        visit "/catalog/#{document_id}"
+        embargo_message_included = page.html.include?("File(s) associated with this object are embargoed until 2033-09-13.")
+        expect(embargo_message_included).to be true
+      end
+    end
+
+    context "and the PDC Describe Work is under an expired embargo" do
+      let(:document_id) { "doi-10-34770-r75s-9j74-expired-embargo" }
+      let(:item_file_fixture) { file_fixture("pdc_describe_expired_embargo.json") }
+      it "does not render the embargo message" do
+        visit "/catalog/#{document_id}"
+        embargo_message_included = page.html.include?("File(s) associated with this object are embargoed until 2033-09-13T00:00:00Z.")
+        expect(embargo_message_included).not_to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Advances https://github.com/pulibrary/pdc_describe/issues/1491 by proposing the following:

- Adding support for embargo dates using the Solr field `embargo_date_dtsi`
- Updating the `show` View template for Solr Documents with embargoed works

![image](https://github.com/pulibrary/pdc_discovery/assets/1443986/56017580-6240-48c8-b49e-105ed2341e17)
