### PR TITLE
Ensuring that there are view templates for 404 responses supporting non-HTML requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,23 @@ class ApplicationController < ActionController::Base
   # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
   layout :determine_layout if respond_to? :layout
+  rescue_from ActionView::MissingTemplate, with: :render_not_found
+
+  def render_not_found
+    error_view = if Rails.env.production? || Rails.env.staging?
+                   '/discovery/errors/not_found'
+                 else
+                   '/errors/not_found'
+                 end
+
+    respond_to do |format|
+      format.html { render error_view, status: :not_found }
+      format.json { head :not_found }
+      format.xml { head :not_found }
+      format.rss { head :not_found }
+      format.any do
+        render "not_found", status: :not_found, formats: [:html]
+      end
+    end
+  end
 end

--- a/spec/requests/errors_spec.rb
+++ b/spec/requests/errors_spec.rb
@@ -15,4 +15,36 @@ RSpec.describe "Errors", type: :request do
       expect(response).to have_http_status(:internal_server_error)
     end
   end
+
+  describe "GET /not_found.json" do
+    it "returns a 404 response code with an empty body" do
+      get "/errors/not_found.json"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "GET /not_found.rss" do
+    it "returns a 404 response code with an empty body" do
+      get "/errors/not_found.rss"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "GET /not_found.xml" do
+    it "returns a 404 response code with an empty body" do
+      get "/errors/not_found.xml"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to be_empty
+    end
+  end
+
+  describe "GET /not_found.svg" do
+    it "returns a 404 response code with an html page" do
+      get "/errors/not_found.svg"
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Resolves #508 