### PR TITLE
Ensuring that HTTP connection errors within Traject indexing functionality are logged as Rails errors and sent to Honeybadger

### DIFF
--- a/lib/traject/import_helper.rb
+++ b/lib/traject/import_helper.rb
@@ -33,6 +33,11 @@ class ImportHelper
     solr_query = File.join(solr_url, "select?q=data_source_ssi:pdc_describe+AND+uri_ssim:\"#{uri}\"")
     response = HTTParty.get(solr_query)
     response.parsed_response["response"]["numFound"] != 0
+  rescue Errno::ECONNREFUSED => connection_error
+    error_message = "HTTP GET request failed for #{solr_query}: #{connection_error}"
+    Rails.logger.error(error_message)
+    Honeybadger.notify(error_message)
+    false
   end
 
   # Calculates the display filename for a PDC Describe file.

--- a/spec/lib/traject/import_helper_spec.rb
+++ b/spec/lib/traject/import_helper_spec.rb
@@ -30,4 +30,25 @@ RSpec.describe ImportHelper do
       expect(globus_folder_uri.include?("origin_path=%2F10.123%2F4567%2F40%2F")).to be true
     end
   end
+
+  describe ".pdc_describe_match_by_uri?" do
+    let(:solr_url) { "https://localhost:8080/solr" }
+    let(:uri) { "https://test.net" }
+    let(:result) { described_class.pdc_describe_match_by_uri?(solr_url, uri) }
+    let(:logger) { instance_double(ActiveSupport::Logger) }
+
+    before do
+      allow(logger).to receive(:error)
+      allow(Rails).to receive(:logger).and_return(logger)
+      allow(Honeybadger).to receive(:notify)
+      allow(HTTParty).to receive(:get).and_raise(Errno::ECONNREFUSED)
+    end
+
+    it "logs an error, notifies Honeybadger, and returns false" do
+      expect(result).to be false
+      solr_query = "https://localhost:8080/solr/select?q=data_source_ssi:pdc_describe+AND+uri_ssim:\"https://test.net\""
+      expect(logger).to have_received(:error).with("HTTP GET request failed for #{solr_query}: Connection refused")
+      expect(Honeybadger).to have_received(:notify).with("HTTP GET request failed for #{solr_query}: Connection refused")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #514 