### PR TITLE
Sharing node_modules between releases to make yarn install faster

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 set :application, "pdc_discovery"
 set :repo_url, "https://github.com/pulibrary/pdc_discovery.git"
 
-set :linked_dirs, %w(log public/system public/assets)
+set :linked_dirs, %w[log public/system public/assets node_modules]
 
 # Default branch is :main
 set :branch, ENV["BRANCH"] || "main"


### PR DESCRIPTION
related to https://github.com/pulibrary/orcid_princeton/issues/57
![Screenshot 2023-11-01 at 8 59 03 AM](https://github.com/pulibrary/pdc_discovery/assets/1599081/c2d852ff-c288-483b-acb1-2e458b111116)
