### PR TITLE
Allow asset precompile on a capistrano roll back

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,6 +25,8 @@ namespace :pdc_discovery do
   end
 end
 
+before "deploy:reverted", "deploy:assets:precompile"
+
 # Uncomment to re-index on every deploy. Only needed when we're actively
 # updating how indexing happens.
 # after "deploy:published", "pdc_discovery:reindex"


### PR DESCRIPTION
@tpendragon pointed out (this issue)[https://github.com/capistrano/npm/issues/7] which suggest allowing npm:install which lead to  the solution implemented in this PR

refs https://github.com/pulibrary/pdc_describe/pull/1596