### PR TITLE
Indexing troubleshooting

### DIFF
--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -12,5 +12,8 @@ production:
   solr_config_set: pdc-discovery-production
 staging:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] %>
+  # Temporarily go straight to a Solr node (lib-solr-staging4)
+  # instead of going through the load balancer (lib-solr8-staging configured via Ansible).
+  # I am not sure this will by pass Zookeper but worth a shot.
+  url: http://lib-solr-staging4.princeton.edu:8983/solr/pdc-discovery-staging
   solr_config_set: pdc-discovery-staging

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -12,8 +12,5 @@ production:
   solr_config_set: pdc-discovery-production
 staging:
   adapter: solr
-  # Temporarily go straight to a Solr node (lib-solr-staging4)
-  # instead of going through the load balancer (lib-solr8-staging configured via Ansible).
-  # I am not sure this will by pass Zookeper but worth a shot.
-  url: http://lib-solr-staging4.princeton.edu:8983/solr/pdc-discovery-staging
+  url: <%= ENV['SOLR_URL'] %>
   solr_config_set: pdc-discovery-staging

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -12,8 +12,10 @@ namespace :index do
 
     Rails.logger.info "Indexing: Fetching PDC Describe records"
     Rake::Task['index:pdc_describe_research_data'].invoke
-    Rails.logger.info "Indexing: Fetching DataSpace records"
-    Rake::Task['index:dspace_research_data'].invoke
+    # ============== Temporarily skip the reindex from DataSpace =========================
+    # Rails.logger.info "Indexing: Fetching DataSpace records"
+    # Rake::Task['index:dspace_research_data'].invoke
+    # ====================================================================================
     Rails.logger.info "Indexing: Fetching completed"
 
     SolrCloudHelper.update_solr_alias!


### PR DESCRIPTION
Troubleshooting issue https://github.com/pulibrary/pdc_discovery/issues/485

Test to see if the Solr reindex issue happens if we don't reindex the data from DataSpace.

It looks to me like the DataSpace reindex is getting stuck (perhaps DataSpace is not responding?) and our reindex never finishes. Then 1/2hr later the rake tasks that reindex starts again and Solr is blocking that second reindex since we never finished the first one.

I've deployed this branch to staging on 11/30/2023 at 11:26 AM. We'll see if the schedule reindex in place works for more than 24 hours this time.

Disabling DataSpace reindexing did not fix the issue. 

12/4/2023 - Pointing directly to a Solr node (`lib-solr-staging4`) instead of the default URL (`lib-solr8-staging` configured via Ansible) that goes through the Load Balancer/Zookeeper (?)

12/7/2023 - Pointing to `lib-solr-staging4` did not help. Reverting the change.
