### PR TITLE
Fixes Plausible issue with downloads 

### DIFF
--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -31,11 +31,15 @@ class Plausible
   def self.downloads(document_id)
     return 'X' if ENV['PLAUSIBLE_KEY'].nil?
 
+    # Plausible API breakdown API: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown
+    # Notice that the Plausible API uses "==" to filter: https://plausible.io/docs/stats-api#filtering
     site_id = Rails.configuration.pdc_discovery.plausible_site_id
+    property = "event:props:filename"
     page = "/discovery/catalog/#{document_id}"
-    # Notice that the Plausible gem use above in pageviews uses "event:page==..." but when we use the raw API
-    # we cannot pass "=="
-    url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=event:props:filename&filters=event:page=#{page}&metrics=visitors,pageviews"
+    filters = "event:page==#{page}"
+    metrics = "visitors,pageviews"
+    period = "12mo"
+    url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=#{property}&filters=#{filters}&metrics=#{metrics}&period=#{period}"
     authorization = "Bearer #{ENV['PLAUSIBLE_KEY']}"
     response = HTTParty.get(url, headers: { 'Authorization' => authorization })
     total_downloads = 0

--- a/spec/models/plausible_spec.rb
+++ b/spec/models/plausible_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 # rubocop:disable Layout/LineLength
 RSpec.describe Plausible do
   before do
-    stub_request(:get, "https://plausible.io/api/v1/stats/breakdown?filters=event:page=/discovery/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu")
+    plausible = "https://plausible.io/api/v1"
+    url = "#{plausible}/stats/breakdown?filters=event:page==/discovery/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu&period=12mo"
+    stub_request(:get, url)
       .with(
         headers: {
           'Accept' => '*/*',


### PR DESCRIPTION
Fixes a couple of issues in the URL we use to fetch downloads:

1. We must use `==` when filtering (instead of `=`). This bug was introduced while troubleshooting a couple of days ago (see PR https://github.com/pulibrary/pdc_discovery/pull/567)
2. Add the `period` parameter to fetch at least 12 months of data since the default value is 30 days!

Moves #568 forward.
