### PR TITLE
Plausible analytics date range

### DIFF
--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -43,7 +43,7 @@ class Plausible
     page = "/discovery/catalog/#{document_id}"
     filters = "event:page==#{page}"
     metrics = "visitors,pageviews"
-    period="custom"
+    period = "custom"
     url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=#{property}&filters=#{filters}&metrics=#{metrics}&period=#{period}&date=#{date_period}"
     authorization = "Bearer #{ENV['PLAUSIBLE_KEY']}"
     response = HTTParty.get(url, headers: { 'Authorization' => authorization })

--- a/app/models/plausible.rb
+++ b/app/models/plausible.rb
@@ -4,13 +4,17 @@ require 'plausible_api'
 class Plausible
   PLAUSIBLE_API_URL = 'https://plausible.io/api/v1'
 
+  def self.date_period
+    "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}"
+  end
+
   # Fetches pageview counts from Plausible for a given document id.
   def self.pageviews(document_id)
     return 'X' if ENV['PLAUSIBLE_KEY'].nil?
 
     c = PlausibleApi::Client.new(Rails.configuration.pdc_discovery.plausible_site_id, ENV['PLAUSIBLE_KEY'])
     page = "/discovery/catalog/#{document_id}"
-    response = c.aggregate({ date: "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}", metrics: 'visitors,pageviews', filters: "event:page==#{page}" })
+    response = c.aggregate({ date: date_period, metrics: 'visitors,pageviews', filters: "event:page==#{page}" })
     response["pageviews"]["value"]
   rescue => e
     Rails.logger.error "PLAUSIBLE ERROR: (Pageviews for document: #{document_id}) #{e.message}"
@@ -33,13 +37,14 @@ class Plausible
 
     # Plausible API breakdown API: https://plausible.io/docs/stats-api#get-apiv1statsbreakdown
     # Notice that the Plausible API uses "==" to filter: https://plausible.io/docs/stats-api#filtering
+    # Time periods: https://plausible.io/docs/stats-api#time-periods
     site_id = Rails.configuration.pdc_discovery.plausible_site_id
     property = "event:props:filename"
     page = "/discovery/catalog/#{document_id}"
     filters = "event:page==#{page}"
     metrics = "visitors,pageviews"
-    period = "12mo"
-    url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=#{property}&filters=#{filters}&metrics=#{metrics}&period=#{period}"
+    period="custom"
+    url = "#{PLAUSIBLE_API_URL}/stats/breakdown?site_id=#{site_id}&property=#{property}&filters=#{filters}&metrics=#{metrics}&period=#{period}&date=#{date_period}"
     authorization = "Bearer #{ENV['PLAUSIBLE_KEY']}"
     response = HTTParty.get(url, headers: { 'Authorization' => authorization })
     total_downloads = 0

--- a/spec/models/plausible_spec.rb
+++ b/spec/models/plausible_spec.rb
@@ -6,7 +6,8 @@ require 'rails_helper'
 RSpec.describe Plausible do
   before do
     plausible = "https://plausible.io/api/v1"
-    url = "#{plausible}/stats/breakdown?filters=event:page==/discovery/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu&period=12mo"
+    date_period = "2021-01-01,#{Time.zone.today.strftime('%Y-%m-%d')}"
+    url = "#{plausible}/stats/breakdown?filters=event:page==/discovery/catalog/88163&metrics=visitors,pageviews&property=event:props:filename&site_id=pdc-discovery-staging.princeton.edu&period=custom&date=#{date_period}"
     stub_request(:get, url)
       .with(
         headers: {


### PR DESCRIPTION
Adjust code to fetch analytics from launch (instead of only the last 12 months)

This is an example of a record that has pageviews older than 12 months and that show that the new parameter picks the correct totals:

```
12mo
{"results":[{"pageviews":1,"visitors":1,"filename":"(none)"}]}

custom&date=2021-01-01,2024-03-13
{"results":[{"pageviews":19,"visitors":13,"filename":"(none)"}]}
```

Closes #568 
