### PR TITLE
JSON endpoint for export

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -254,6 +254,13 @@ class CatalogController < ApplicationController
     ]
   end
 
+  def show
+    super
+    if params["format"] == "json"
+      render json: DocumentExport.new(@document)
+    end
+  end
+
   # Returns the raw BibTex citation information
   def bibtex
     _unused, @document = search_service.fetch(params[:id])

--- a/app/models/document_export.rb
+++ b/app/models/document_export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DocumentExport
   attr_reader :id, :title, :files
 

--- a/app/models/document_export.rb
+++ b/app/models/document_export.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class DocumentExport
-  attr_reader :id, :title, :files, :description, :abstract
+  attr_reader :id, :title, :files, :description, :abstract, :rights, :authors, :doi_value, :doi_url,
+    :total_file_size, :embargo_date, :globus_url
 
   def initialize(solr_document)
     @id = solr_document.id
@@ -9,5 +10,12 @@ class DocumentExport
     @files = solr_document.files
     @description = solr_document.description
     @abstract = solr_document.abstract
+    @rights = solr_document.rights_enhanced
+    @authors = solr_document.authors_ordered
+    @doi_value = solr_document.doi_value
+    @doi_url = solr_document.doi_url
+    @total_file_size = solr_document.total_file_size
+    @embargo_date = solr_document.embargo_date
+    @globus_url = solr_document.globus_uri
   end
 end

--- a/app/models/document_export.rb
+++ b/app/models/document_export.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 class DocumentExport
-  attr_reader :id, :title, :files
+  attr_reader :id, :title, :files, :description, :abstract
 
   def initialize(solr_document)
     @id = solr_document.id
     @title = solr_document.title
     @files = solr_document.files
+    @description = solr_document.description
+    @abstract = solr_document.abstract
   end
 end

--- a/app/models/document_export.rb
+++ b/app/models/document_export.rb
@@ -1,0 +1,9 @@
+class DocumentExport
+  attr_reader :id, :title, :files
+
+  def initialize(solr_document)
+    @id = solr_document.id
+    @title = solr_document.title
+    @files = solr_document.files
+  end
+end

--- a/spec/models/document_export_spec.rb
+++ b/spec/models/document_export_spec.rb
@@ -3,10 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe DocumentExport do
+  let(:files_pdc_describe) {
+    [{ name: "file1.zip", full_name: "/folder1/file1.zip", size: 27, url: "https://pdc_describe" }, { name: "data.csv" }, { name: "file2.zip" }]
+  }
+
+  let(:files_dataspace) {
+    [{ name: "file1.zip", size: 27, handle: "xyz" }, { name: "data.csv", size: 29, handle: "yzx" }, { name: "file2.zip", size: 28, handle: "zxy" }]
+  }
+
+  let(:solr_doc_pdc_describe) {
+    SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files_pdc_describe.to_json, data_source_ssi: "pdc_describe", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
+  }
+
+  let(:solr_doc_dataspace) {
+    SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files_dataspace.to_json, data_source_ssi: "dataspace", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
+  }
+
   it "returns DocumentExport object's information from pdc_describe" do
-    files = [{ name: "file1.zip", full_name: "/folder1/file1.zip", size: 27, url: "https://pdc_describe" }, { name: "data.csv" }, { name: "file2.zip" }]
-    solr_doc = SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files.to_json, data_source_ssi: "pdc_describe", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
-    document = described_class.new(solr_doc)
+    document = described_class.new(solr_doc_pdc_describe)
     expect(document.id).to be "1"
     expect(document.title).to be "Hello World"
     expect(document.files.count).to eq 3
@@ -18,9 +32,7 @@ RSpec.describe DocumentExport do
   end
 
   it "returns DocumentExport object's information from dataspace" do
-    files = [{ name: "file1.zip", size: 27, handle: "xyz" }, { name: "data.csv", size: 29, handle: "yzx" }, { name: "file2.zip", size: 28, handle: "zxy" }]
-    solr_doc = SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files.to_json, data_source_ssi: "dataspace", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
-    document = described_class.new(solr_doc)
+    document = described_class.new(solr_doc_dataspace)
     expect(document.id).to be "1"
     expect(document.title).to be "Hello World"
     expect(document.files.count).to eq 3

--- a/spec/models/document_export_spec.rb
+++ b/spec/models/document_export_spec.rb
@@ -2,22 +2,32 @@
 
 require 'rails_helper'
 
+# rubocop:disable Layout/LineLength
 RSpec.describe DocumentExport do
-  let(:files_pdc_describe) {
-    [{ name: "file1.zip", full_name: "/folder1/file1.zip", size: 27, url: "https://pdc_describe" }, { name: "data.csv" }, { name: "file2.zip" }]
-  }
+  let(:files_pdc_describe) do
+    [{ name: "file1.zip", full_name: "/folder1/file1.zip", size: 27, url: "https://pdc_describe" }, { name: "data.csv", size: 100 }, { name: "file2.zip", size: 200 }]
+  end
 
-  let(:files_dataspace) {
+  let(:files_dataspace) do
     [{ name: "file1.zip", size: 27, handle: "xyz" }, { name: "data.csv", size: 29, handle: "yzx" }, { name: "file2.zip", size: 28, handle: "zxy" }]
-  }
+  end
 
-  let(:solr_doc_pdc_describe) {
-    SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files_pdc_describe.to_json, data_source_ssi: "pdc_describe", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
-  }
+  let(:solr_doc_pdc_describe) do
+    SolrDocument.new({
+                       id: "1", title_tesim: ["Hello World"], files_ss: files_pdc_describe.to_json,
+                       data_source_ssi: "pdc_describe",
+                       description_tsim: ["Something"],
+                       abstract_tsim: ["Abstract"],
+                       uri_ssim: ["https://doi.org/10.34770/bm4s-t361"],
+                       embargo_date_dtsi: "2025-11-28",
+                       globus_uri_ssi: "https://app.globus.org/file-manager?origin_id=something-something",
+                       authors_json_ss: "[{\"value\":\"Alt, Andrew\",\"name_type\":\"Personal\",\"given_name\":\"Andrew\",\"family_name\":\"Alt\",\"identifier\":{\"value\":\"0000-0001-9475-8282\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":0},{\"value\":\"Ji, Hantao\",\"name_type\":\"Personal\",\"given_name\":\"Hantao\",\"family_name\":\"Ji\",\"identifier\":{\"value\":\"0000-0001-9600-9963\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":1},{\"value\":\"Yoo, Jongsoo\",\"name_type\":\"Personal\",\"given_name\":\"Jongsoo\",\"family_name\":\"Yoo\",\"identifier\":{\"value\":\"0000-0003-3881-1995\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":2},{\"value\":\"Bose, Sayak\",\"name_type\":\"Personal\",\"given_name\":\"Sayak\",\"family_name\":\"Bose\",\"identifier\":{\"value\":\"0000-0001-8093-9322\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":3},{\"value\":\"Goodman, Aaron\",\"name_type\":\"Personal\",\"given_name\":\"Aaron\",\"family_name\":\"Goodman\",\"identifier\":{\"value\":\"0000-0003-3639-6572\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":4},{\"value\":\"Yamada, Masaaki\",\"name_type\":\"Personal\",\"given_name\":\"Masaaki\",\"family_name\":\"Yamada\",\"identifier\":{\"value\":\"0000-0003-4996-1649\",\"scheme\":\"ORCID\",\"scheme_uri\":\"https://orcid.org\"},\"affiliations\":[{\"value\":\"Princeton Plasma Physics Laboratory\",\"identifier\":\"https://ror.org/03vn1ts68\",\"scheme\":\"ROR\",\"scheme_uri\":null}],\"sequence\":5}]"
+                     })
+  end
 
-  let(:solr_doc_dataspace) {
+  let(:solr_doc_dataspace) do
     SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files_dataspace.to_json, data_source_ssi: "dataspace", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
-  }
+  end
 
   it "returns DocumentExport object's information from pdc_describe" do
     document = described_class.new(solr_doc_pdc_describe)
@@ -29,6 +39,13 @@ RSpec.describe DocumentExport do
     expect(document.files.first.name).to eq "file1.zip"
     expect(document.files.first.full_path).to eq "/folder1/file1.zip"
     expect(document.files.first.download_url).to eq "https://pdc_describe"
+    expect(document.doi_value).to eq "10.34770/bm4s-t361"
+    expect(document.doi_url).to eq "https://doi.org/10.34770/bm4s-t361"
+    expect(document.embargo_date).to eq Date.parse("2025-11-28")
+    expect(document.total_file_size).to eq 327
+    expect(document.globus_url).to eq "https://app.globus.org/file-manager?origin_id=something-something"
+    expect(document.authors.count).to be 6
+    expect(document.authors[0].value).to eq "Alt, Andrew"
   end
 
   it "returns DocumentExport object's information from dataspace" do
@@ -42,3 +59,4 @@ RSpec.describe DocumentExport do
     expect(document.files.first.download_url).to eq "https://dataspace-dev.princeton.edu/bitstream/xyz/0"
   end
 end
+# rubocop:enable Layout/LineLength

--- a/spec/models/document_export_spec.rb
+++ b/spec/models/document_export_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DocumentExport do
+  it "returns DocumentExport object's information from pdc_describe" do
+    files = [{ name: "file1.zip", full_name: "/folder1/file1.zip", size: 27, url: "https://pdc_describe" }, { name: "data.csv" }, { name: "file2.zip" }]
+    solr_doc = SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files.to_json, data_source_ssi: "pdc_describe", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
+    document = described_class.new(solr_doc)
+    expect(document.id).to be "1"
+    expect(document.title).to be "Hello World"
+    expect(document.files.count).to eq 3
+    expect(document.description).to eq "Something"
+    expect(document.abstract).to eq "Abstract"
+    expect(document.files.first.name).to eq "file1.zip"
+    expect(document.files.first.full_path).to eq "/folder1/file1.zip"
+    expect(document.files.first.download_url).to eq "https://pdc_describe"
+  end
+
+  it "returns DocumentExport object's information from dataspace" do
+    files = [{ name: "file1.zip", size: 27, handle: "xyz" }, { name: "data.csv", size: 29, handle: "yzx" }, { name: "file2.zip", size: 28, handle: "zxy" }]
+    solr_doc = SolrDocument.new({ id: "1", title_tesim: ["Hello World"], files_ss: files.to_json, data_source_ssi: "dataspace", description_tsim: ["Something"], abstract_tsim: ["Abstract"] })
+    document = described_class.new(solr_doc)
+    expect(document.id).to be "1"
+    expect(document.title).to be "Hello World"
+    expect(document.files.count).to eq 3
+    expect(document.description).to eq "Something"
+    expect(document.abstract).to eq "Abstract"
+    expect(document.files.first.name).to eq "file1.zip"
+    expect(document.files.first.download_url).to eq "https://dataspace-dev.princeton.edu/bitstream/xyz/0"
+  end
+end


### PR DESCRIPTION
Updated the code to use our own metadata when requesting the JSON version of a record. This new version includes several properties (not included on the default endpoint provided by Blacklight) including the file list, DOI, authors' ORCID information, and the Globus URL.

Co-authored-by: Claudia Lee <claudiawulee@users.noreply.github.com>

Closes #598