### PR TITLE
Remove Rails Spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ group :development do
   gem "ed25519"
   gem "foreman"
   gem 'rack-mini-profiler', '~> 2.0'
-  gem 'spring'
   gem 'web-console', '>= 4.1.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,7 +458,6 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
-    spring (4.1.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -595,7 +594,6 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver
-  spring
   thor
   traject
   turbolinks (~> 5)


### PR DESCRIPTION
Remove Rails Spring from the project. We are not using it in any of our other applications and it causes all sort of weird bug during development, for example:

```
Running via Spring preloader in process 41493
objc[41493]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
objc[41493]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. 
We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on 
objc_initializeAfterForkError to debug.
```