### PR TITLE
Error handling when indexing DataSpace datasets

### DIFF
--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -26,11 +26,6 @@ namespace :index do
     DspaceResearchDataHarvester.harvest(false)
     SolrCloudHelper.collection_writer_commit!
     Rails.logger.info "Indexing: Harvesting and indexing DataSpace research data collections completed"
-  rescue => ex
-    # DataSpace errors quite often.
-    # Log the exception and let other process continue.
-    Rails.logger.error("Indexing: Error harvesting data from DataSpace: #{ex.message}")
-    Honeybadger.notify("Indexing: Error harvesting data from DataSpace: #{ex.message}")
   end
 
   desc 'Index all PDC Describe data'


### PR DESCRIPTION
This PR undoes a commit that I did as part of this PR: https://github.com/pulibrary/pdc_discovery/pull/620/files

Catching the DataSpace exception has the unintended consequence of continuing the indexing process (which sounds like a good idea) but that results in a new index with no DataSpace records.

In this PR I am letting the exception flow (as it did before) which stops the indexing process and keeps the previous data in place. Not ideal but all in all a better outcome than blowing away the DataSpace records every time DataSpace is not available during the reindex process, which sadly is quite common.


