### PR TITLE
Ensuring that `rails_helper` is consistently required (rather than`spec_helper`) ensuring that `coveralls` is required before `simplecov`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,11 @@ jobs:
       - run:
           name: Run Rspec
           command: COVERALLS_REPO_TOKEN=$COVERALLS_REPO_TOKEN bundle exec rspec
+      - store_artifacts:
+          path:
+            ~/pdc_discovery/coverage
+            ~/pdc_discovery/tmp/capybara
+            ~/pdc_discovery/tmp/screenshots
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem "rspec-retry"
   gem 'rspec-solr'
   gem 'rubocop-rspec'
+  gem "simplecov", "~> 0.22"
   gem 'yard'
 end
 
@@ -68,7 +69,7 @@ end
 group :test do
   gem 'axe-core-rspec'
   gem 'capybara', '>= 3.26'
-  gem 'coveralls_reborn', '~> 0.24.0', require: false
+  gem "coveralls_reborn", require: false
   gem 'selenium-webdriver'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'whenever'
 group :development, :test do
   gem 'bixby'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem "coveralls_reborn", "~> 0.28"
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec'
@@ -69,7 +70,6 @@ end
 group :test do
   gem 'axe-core-rspec'
   gem 'capybara', '>= 3.26'
-  gem "coveralls_reborn", require: false
   gem 'selenium-webdriver'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,11 +149,11 @@ GEM
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.3)
-    coveralls_reborn (0.24.0)
-      simplecov (>= 0.18.1, < 0.22.0)
-      term-ansicolor (~> 1.6)
-      thor (>= 0.20.3, < 2.0)
-      tins (~> 1.16)
+    coveralls_reborn (0.28.0)
+      simplecov (~> 0.22.0)
+      term-ansicolor (~> 1.7)
+      thor (~> 1.2)
+      tins (~> 1.32)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -480,7 +480,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    simplecov (0.21.2)
+    simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
@@ -605,7 +605,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails (~> 1.4)
   capybara (>= 3.26)
-  coveralls_reborn (~> 0.24.0)
+  coveralls_reborn
   devise
   devise-guests (~> 0.6)
   ed25519
@@ -637,6 +637,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver
+  simplecov (~> 0.22)
   strscan (>= 3.1.0)
   thor
   traject

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -605,7 +605,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails (~> 1.4)
   capybara (>= 3.26)
-  coveralls_reborn
+  coveralls_reborn (~> 0.28)
   devise
   devise-guests (~> 0.6)
   ed25519

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module PdcDiscovery
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths << Rails.root.join("app", "lib")
 
     config.pdc_discovery = config_for(:pdc_discovery)
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe ApplicationHelper, type: :helper do
   describe "#render_field_row_search_link" do
     let(:title) { "Domain" }

--- a/spec/helpers/sidebar_helper_spec.rb
+++ b/spec/helpers/sidebar_helper_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe SidebarHelper, type: :helper do
   describe "#render_sidebar_related_identifiers" do
     let(:text_id) { { "related_identifier" => "123", "relation_type" => "IsCitedBy" } }

--- a/spec/lib/date_normalizer_spec.rb
+++ b/spec/lib/date_normalizer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe DateNormalizer do
   let(:years) { ['2015'] }
   let(:months_and_years) { ['2015-08'] }

--- a/spec/lib/domain_spec.rb
+++ b/spec/lib/domain_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "rails_helper"
 require "./lib/traject/domain.rb"
 
 RSpec.describe Domain do

--- a/spec/lib/dspace_indexer_spec.rb
+++ b/spec/lib/dspace_indexer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe DspaceIndexer do
   describe 'indexing a community from DataSpace' do
     let(:community_fetch_with_expanded_metadata) { File.read(File.join(fixture_path, 'astrophysical_sciences.xml')) }

--- a/spec/lib/research_data_collection_spec.rb
+++ b/spec/lib/research_data_collection_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe ResearchDataCollection do
   let(:csv_data) do
     {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
+# Add additional requires below this line. Rails is not loaded until this point!
 
 # This *must* be required before simplecov
 require "coveralls"
@@ -21,13 +22,7 @@ SimpleCov.start "rails" do
   formatter(multi)
 end
 
-require "spec_helper"
-
 require 'rspec/rails'
-require 'axe-rspec'
-
-# Add additional requires below this line. Rails is not loaded until this point!
-require 'webmock/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -42,7 +37,10 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
+
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+require "spec_helper"
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -53,6 +51,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include Rails.application.routes.url_helpers
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec', 'fixtures').to_s
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
-
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+
+require "simplecov"
+require "simplecov_json_formatter"
+SimpleCov.start "rails" do
+  multi = SimpleCov::Formatter::MultiFormatter.new([
+                                                     SimpleCov::Formatter::SimpleFormatter,
+                                                     SimpleCov::Formatter::HTMLFormatter,
+                                                     SimpleCov::Formatter::JSONFormatter
+                                                   ])
+  formatter(multi)
+end
+
 require 'spec_helper'
 
 ENV['RAILS_ENV'] ||= 'test'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 
+ENV['RAILS_ENV'] ||= 'test'
+require File.expand_path('../config/environment', __dir__)
+# Prevent database truncation if the environment is production
+abort('The Rails environment is running in production mode!') if Rails.env.production?
+
+# This *must* be required before simplecov
+require "coveralls"
+Coveralls.wear!("rails")
+
 require "simplecov"
 require "simplecov_json_formatter"
 SimpleCov.start "rails" do
@@ -12,12 +21,8 @@ SimpleCov.start "rails" do
   formatter(multi)
 end
 
-require 'spec_helper'
+require "spec_helper"
 
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
-# Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'axe-rspec'
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,21 +7,6 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# This *must* be required before simplecov
-require "coveralls"
-Coveralls.wear!("rails")
-
-require "simplecov"
-require "simplecov_json_formatter"
-SimpleCov.start "rails" do
-  multi = SimpleCov::Formatter::MultiFormatter.new([
-                                                     SimpleCov::Formatter::SimpleFormatter,
-                                                     SimpleCov::Formatter::HTMLFormatter,
-                                                     SimpleCov::Formatter::JSONFormatter
-                                                   ])
-  formatter(multi)
-end
-
 require 'rspec/rails'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -41,6 +26,21 @@ require 'rspec/rails'
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 require "spec_helper"
+
+# This *must* be required before simplecov
+require "coveralls"
+Coveralls.wear!("rails")
+
+require "simplecov"
+require "simplecov_json_formatter"
+SimpleCov.start "rails" do
+  multi = SimpleCov::Formatter::MultiFormatter.new([
+                                                     SimpleCov::Formatter::SimpleFormatter,
+                                                     SimpleCov::Formatter::HTMLFormatter,
+                                                     SimpleCov::Formatter::JSONFormatter
+                                                   ])
+  formatter(multi)
+end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "coveralls"
-Coveralls.wear!("rails")
-
-require "rails_helper"
-
 require 'rspec-solr'
 
 # Adds the ability to retry flaky tests.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "coveralls"
+Coveralls.wear!("rails")
+
+require "rails_helper"
+
 require 'rspec-solr'
-require 'coveralls'
-Coveralls.wear!
 
 # Adds the ability to retry flaky tests.
 # See https://github.com/NoRedInk/rspec-retry

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "pry-byebug"
+require 'axe-rspec'
+require 'webmock/rspec'
+
 require 'rspec-solr'
 
 # Adds the ability to retry flaky tests.
@@ -22,7 +26,6 @@ require "rspec/retry"
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.include Rails.application.routes.url_helpers
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/system/default_search_spec.rb
+++ b/spec/system/default_search_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'spec_helper'
+require 'rails_helper'
 
 describe "Default search", type: :system do
   context "indexing all text" do


### PR DESCRIPTION
Advances #650 