### PR TITLE
Adds the new about page text

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -12,79 +12,37 @@
 
 <h3>What's new?</h3>
 <p>
-The Princeton research data repository has a new front-end, called Princeton Data Commons: Discovery. This is an early 
-    release of our evolving discovery layer, and we are welcoming feedback from everyone. Please email us at 
-    <a href="mailto:prds@princeton.edu">prds@princeton.edu</a> with any questions or comments.</p>
+In April 2024, Princeton University Library launched Princeton Data Commons, a new custom built data repository which
+  replaced DataSpace. We are working to improve upon this first release and welcome feedback at
+  <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>.</p>
 
 <h3>Why does Princeton University have an online data repository?</h3>
-<p>Princeton University is committed to supporting research that has the potential to benefit humanity at large. 
-    Very often, research conducted by members of the Princeton community is publicly funded and therefore entails an 
-    explicit responsibility to share the products of the research openly with taxpayers. Some academic journals have 
-    data policies requiring that the evidence backing submitted research papers be posted online for peer review and 
-    public scrutiny. An increasing number of Princeton researchers also embrace the principles of open research in general, 
-    committing to share their data and/or code for the sake of transparency, accountability, and the democratization of 
-    knowledge, regardless of whether their funders and publishers require it. This repository exists to support long-term 
-    archiving and open dissemination of any digital research product from the Princeton community, meeting funder and 
-    publisher policies, as well as open research principles.<p>
+<p>Princeton University is committed to supporting research that has the potential to benefit humanity at large. Very often, 
+  research conducted by members of the Princeton community is publicly funded and therefore entails an explicit responsibility 
+  to share the products of the research openly with taxpayers. Some academic journals have data policies requiring that the 
+  evidence backing submitted research papers be posted online for peer review and public scrutiny. An increasing number of 
+  Princeton researchers also embrace the principles of open research in general, committing to share their data and/or code 
+  for the sake of transparency, accountability, and the democratization of knowledge, regardless of whether their funders and 
+  publishers require it. This repository exists to support long-term archiving and open dissemination of any digital research 
+  product from the Princeton community, meeting funder and publisher policies, as well as open research principles.<p>
 
 <h3>Who has access to items in the repository?</h3>
 <p>Anyone can browse, download, and investigate the items, free of charge. Many, if not most, of these items have an 
     intended audience of specialists in a given field of research, and users should be cautioned that individual contributors 
-    typically retain copyrights to their research works, so permissions may be required for some forms of use and re-use, 
+    typically retain copyrights to their research works. Permissions may be required for some forms of use and re-use, 
     depending on the item.</p>
 
 <h3>Who manages Princeton's Research Data Repository?</h3>
 <p>Data are curated and published by the <a href="https://researchdata.princeton.edu/">Princeton Research Data Service</a>
     (PRDS), with technical and infrastructure support from information technology staff at the Princeton University Library. 
-    PRDS curators review submissions with an eye toward discoverability, reusability, and long-term preservation - without 
+    PRDS curators review submissions with an eye toward discoverability, reusability, and long-term preservation; without 
     partiality to the subject matter or findings of the research.</p>
 
-    <p>For general questions related to the repository, please contact the curators.</p>
-
-<h3>The Repository Team</h3>
-<h4>Curation Service, Princeton Research Data Service (PRDS)</h4>
-<ul>
-  <li>Halle Burns - Research Data Management Specialist</li>
-  <li>Sarah Reiff Conell - Research Data Management Specialist</li>
-  <li>Neggin Keshavarzian - Senior Research Data Management Specialist</li>
-</ul>
-<h4>Repository Management, Princeton Research Data Service (PRDS)</h4>
-<ul>
-  <li>Matt Chandler - Lead for Research Data Infrastructure Services</li>
-</ul>
-<h4>Other Contributors</h4>
-<ul>
-  <li>Chun Ly - Division Manager, Research Publications and Data Management, Princeton Plasma Physics Laboratory</li>
-  <li>Meghan Testerman, Open Research and Scholarship Librarian and Head of Princeton Research Data Service (PRDS), Princeton University Library</li>
-  <li>Hannah Hadley - Manager of Open Publishing and Repository Services, Princeton University Library</li>
-  <li>Jen Greyburn, Assistant Director of Research Data and Open Scholarship, Princeton University Library</li>
-</ul>
-<h4>Project Administration</h4>
-<ul>
-  <li>Wind Cowles - Associate Dean, Data, Research and Teaching, Princeton University Library</li>
-</ul>
-<h3>Infrastructure Development</h3>
-<h4>Research Data and Scholarship Services (RDSS)</h4>
-<ul>
-  <li>Tyler Wade - Cataloging and Metadata Services Fellow</li>
-  <li>Bess Sadler - Senior Library Software Engineer</li>
-  <li>Carolyn Cole - Senior Library Software Engineer</li>
-  <li>Hector Correa - Senior Library Software Engineer</li>
-  <li>James Griffin - Library Software Engineer</li>
-  <li>Kate Lynch - Lead Library Software Engineer</li>
-</ul>
-<h4>Library IT Operations</h4>
-<ul>
-  <li>Robert-Anthony Lee-Faison - IT Operations Fellow</li>
-  <li>Francis Kayiwa - Developer Operations Engineer</li>
-  <li>Alicia Cozine - Library Operations Engineer</li>
-</ul>
-<h4>Emeritus Contributors</h4>
-<p>Rishi Joshi, Chuck McCallum</p>
+    <p>For general questions related to the repository, please contact 
+      <a href="mailto:prds@princeton.edu">prds@princeton.edu</a>.</p>
 
 <h3>About the Princeton Data Commons (PDC) project</h3>
 <p>The Princeton Data Commons is a project to create an ecosystem of online resources and tools to support and advance
-    storing, preserving, managing, sharing, and curating digital research data. Princeton Data Commons - Discovery
-    is the first application in this new ecosystem. For more information about the PDC project, please contact Wind
-    Cowles, Director of Research Data and Open Scholarship
-    (<a href="mailto:windcowles@princeton.edu">windcowles@princeton.edu</a>).</p>
+    storing, preserving, managing, sharing, and curating digital research data. For more information about the PDC project, 
+    please contact Meghan Testerman, Head of Princeton Research Data Service 
+    (<a href="mailto:mtesterman@princeton.edu">mtesterman@princeton.edu</a>).</p>


### PR DESCRIPTION
Resolves #649 by updating the text of the about page. The About Page test did not need to be updated. See view below:
<img width="895" alt="Screenshot 2024-07-31 at 4 21 15 PM" src="https://github.com/user-attachments/assets/a787016a-078e-4761-ac2d-72101ad54396">
