### PR TITLE
Load file list on the background on the Show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -268,12 +268,11 @@ class CatalogController < ApplicationController
     end
   end
 
+  # This endpoint is used to feed the AJAX call on the Show page for the file list and
+  # therefore the return JSON must be something that DataTables can use.
   def file_list
     document = solr_find(params["id"])
-
-    file1 = {name: "hello.txt", size: 123}
-    file2 = {name: "bye.txt", size: 222}
-    file_list = {data: [file1, file2]}
+    file_list = {data: document.files}
 
     render json: file_list.to_json
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,7 +272,7 @@ class CatalogController < ApplicationController
   # therefore the return JSON must be something that DataTables can use.
   def file_list
     document = solr_find(params["id"])
-    file_list = {data: document.files}
+    file_list = { data: document.files }
 
     render json: file_list.to_json
   end
@@ -350,15 +350,13 @@ class CatalogController < ApplicationController
   end
 
   private
-    def solr_find(id)
-      solr_url = Blacklight.default_configuration.connection_config[:url]
-      solr = RSolr.connect(url: solr_url)
-      solr_params = {
-        q: "id:#{id}",
-        fl: '*',
-      }
-      response = solr.get('select', params: solr_params)
-      solr_doc = response["response"]["docs"][0]
-      SolrDocument.new(solr_doc)
-    end
+
+  def solr_find(id)
+    solr_url = Blacklight.default_configuration.connection_config[:url]
+    solr = RSolr.connect(url: solr_url)
+    solr_params = { q: "id:#{id}", fl: '*' }
+    response = solr.get('select', params: solr_params)
+    solr_doc = response["response"]["docs"][0]
+    SolrDocument.new(solr_doc)
+  end
 end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -268,6 +268,16 @@ class CatalogController < ApplicationController
     end
   end
 
+  def file_list
+    document = solr_find(params["id"])
+
+    file1 = {name: "hello.txt", size: 123}
+    file2 = {name: "bye.txt", size: 222}
+    file_list = {data: [file1, file2]}
+
+    render json: file_list.to_json
+  end
+
   # Returns the raw BibTex citation information
   def bibtex
     _unused, @document = search_service.fetch(params[:id])
@@ -339,4 +349,17 @@ class CatalogController < ApplicationController
       format.json { render json: @documents }
     end
   end
+
+  private
+    def solr_find(id)
+      solr_url = Blacklight.default_configuration.connection_config[:url]
+      solr = RSolr.connect(url: solr_url)
+      solr_params = {
+        q: "id:#{id}",
+        fl: '*',
+      }
+      response = solr.get('select', params: solr_params)
+      solr_doc = response["response"]["docs"][0]
+      SolrDocument.new(solr_doc)
+    end
 end

--- a/app/models/dataset_file.rb
+++ b/app/models/dataset_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DatasetFile
-  attr_accessor :name, :description, :format, :size, :mime_type, :sequence, :handle, :extension,
+  attr_accessor :name, :description, :format, :size, :display_size, :mime_type, :sequence, :handle, :extension,
     :source, :download_url, :full_path
 
   def self.from_hash(data, data_source)
@@ -23,6 +23,7 @@ class DatasetFile
     file.description = hash[:description]
     file.mime_type = hash[:mime_type]
     file.size = hash[:size]
+    file.display_size = ActiveSupport::NumberHelper.number_to_human_size(file.size)
     file.sequence = (hash[:sequence] || "").to_i
     # Technically the handle is a property of the dataset item rather than the file (aka bitstream)
     # but we store it at the file level for convenience.
@@ -40,6 +41,7 @@ class DatasetFile
     file.extension = File.extname(file.name)
     file.extension = file.extension[1..] if file.extension != "." # drop the leading period
     file.size = hash[:size]
+    file.display_size = ActiveSupport::NumberHelper.number_to_human_size(file.size)
     file.download_url = hash[:url]
     file
   end

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -13,14 +13,17 @@
           <table id="files-table" class="table">
             <thead>
               <tr>
-                <th scope="col" nowrap="nowrap"><span>#</span></th>
-                <th scope="col" nowrap="nowrap"><span>Filename</span></th>
-                <th scope="col" nowrap="nowrap"><span>Filesize</span></th>
+                  <th>Name</th>
+                  <th>Size</th>
               </tr>
             </thead>
-            <tbody>
-            </tbody>
-            <tfoot></tfoot>
+            <tbody></tbody>
+            <tfoot>
+              <tr>
+                  <th>Name</th>
+                  <th>Size</th>
+              </tr>
+            </tfood>
           </table>
         <% end %>
 
@@ -35,9 +38,13 @@
 <script type="text/javascript">
 $(function() {
 
-  // Wire DataTable for the file list.
-  // TODO: Update to load via AJAX
-  $('#files-table').DataTable();
+  $('#files-table').DataTable({
+    ajax: "<%= catalog_file_list_path(@document) %>",
+    columns: [
+        { data: 'name' },
+        { data: 'size' }
+    ]
+  });
 
   // Track file downloads via Plausible.
   $(".documents-file-link").click(function() {

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -15,38 +15,10 @@
               <tr>
                 <th scope="col" nowrap="nowrap"><span>#</span></th>
                 <th scope="col" nowrap="nowrap"><span>Filename</span></th>
-                <% if @document.data_source == "dataspace" %>
-                  <th scope="col"><span>Description</span></th>
-                <% end %>
                 <th scope="col" nowrap="nowrap"><span>Filesize</span></th>
               </tr>
             </thead>
             <tbody>
-              <% DatasetFile.sort_file_array(@document.files).each_with_index do |file, ix| %>
-                <tr class="document-download">
-                  <th scope="row">
-                    <span><span><%= ix + 1 %></span></span>
-                  </th>
-                  <td>
-                    <span>
-                      <i class="bi bi-file-arrow-down"></i>
-                      <% if @render_links%>
-                        <a href="<%= file.download_url %>" class="documents-file-link" target="_blank" title="<%= file.full_path %>"><%= truncate(file.full_path, length: 60) %></a>
-                      <% else %>
-                        <%= truncate(file.full_path, length: 60) %>
-                      <% end %>
-                    </span>
-                  </td>
-                  <% if @document.data_source == "dataspace" %>
-                    <td>
-                      <span><%= file.description %></span>
-                    </td>
-                  <% end %>
-                  <td data-order="<%= file.size %>">
-                    <span><span><%= number_to_human_size(file.size) %></span></span>
-                  </td>
-                </tr>
-              <% end %>
             </tbody>
             <tfoot></tfoot>
           </table>
@@ -64,6 +36,7 @@
 $(function() {
 
   // Wire DataTable for the file list.
+  // TODO: Update to load via AJAX
   $('#files-table').DataTable();
 
   // Track file downloads via Plausible.

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -13,17 +13,11 @@
           <table id="files-table" class="table">
             <thead>
               <tr>
-                  <th>Name</th>
+                  <th>Filename</th>
                   <th>Size</th>
               </tr>
             </thead>
             <tbody></tbody>
-            <tfoot>
-              <tr>
-                  <th>Name</th>
-                  <th>Size</th>
-              </tr>
-            </tfood>
           </table>
         <% end %>
 
@@ -41,8 +35,40 @@ $(function() {
   $('#files-table').DataTable({
     ajax: "<%= catalog_file_list_path(@document) %>",
     columns: [
-        { data: 'name' },
+        { data: 'full_path' },
         { data: 'size' }
+    ],
+    columnDefs: [
+      {
+        // filename
+        render: function (data, type, row) {
+          if (type == "display") {
+            html = `<a href="${row.download_url}">${data}</a>`;
+            return html;
+          }
+
+          // Force any readme file to sort to the top
+          var sortValue;
+          if (data.toLowerCase().includes("readme")) {
+            sortValue = "A" + data;
+          } else {
+            sortValue = "Z" + data;
+          }
+          return sortValue;
+        },
+        targets: 0,
+      },
+      {
+        // file size
+        render: function (data, type, row) {
+          if (type == "display") {
+            return row.display_size;
+          }
+          return parseInt(data, 10);
+        },
+        targets: 1,
+        className: 'dt-right'
+      }
     ]
   });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   get 'pppl_reporting_feed' => 'catalog#pppl_reporting_feed', as: :pppl_reporting_feed
 
   get 'catalog/:id/bibtex' => 'catalog#bibtex', as: :catalog_bibtex
+  get 'catalog/:id/file-list' => 'catalog#file_list', as: :catalog_file_list
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
     concerns :searchable

--- a/spec/system/show_pdc_describe_record_spec.rb
+++ b/spec/system/show_pdc_describe_record_spec.rb
@@ -30,14 +30,14 @@ describe 'Show PDC Page', type: :system, js: true do
   end
   it 'has the README files first' do
     visit '/catalog/doi-10-34770-bm4s-t361'
-    sleep(0.5)
+    sleep(0.1) # wait for the files to load via AJAX
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     expect(first_filename_spot).to eq("Fig11b_readme.hdf")
   end
 
   it "reports sizes using MB and KB" do
     visit '/catalog/doi-10-34770-bm4s-t361'
-    sleep(0.5)
+    sleep(0.1) # wait for the files to load via AJAX
     # These tests are to validate our monkey-patched number_to_human_size (see number_to_human_size_converter.rb)
     # is dividing the size by 1000 instead of using the Rails default of 1024.
     file_size = find(:css, '#files-table>tbody>tr:first-child>td:nth-child(2)', match: :first).text
@@ -53,10 +53,10 @@ describe 'Show PDC Page', type: :system, js: true do
   end
   it 'correctly sorts by file size' do
     visit '/catalog/doi-10-34770-bm4s-t361'
-    sleep(0.5)
+    sleep(0.1) # wait for the files to load via AJAX
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     expect(first_filename_spot).to eq("Fig11b_readme.hdf")
-    find(:xpath, "//thead/tr/th[2]").click  # sort by file size
+    find(:xpath, "//thead/tr/th[2]").click # sort by file size
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     # "readme.txt" is the smallest file and so now it is first
     expect(first_filename_spot).to eq("readme.txt")

--- a/spec/system/show_pdc_describe_record_spec.rb
+++ b/spec/system/show_pdc_describe_record_spec.rb
@@ -30,17 +30,19 @@ describe 'Show PDC Page', type: :system, js: true do
   end
   it 'has the README files first' do
     visit '/catalog/doi-10-34770-bm4s-t361'
+    sleep(0.5)
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     expect(first_filename_spot).to eq("Fig11b_readme.hdf")
   end
 
   it "reports sizes using MB and KB" do
     visit '/catalog/doi-10-34770-bm4s-t361'
+    sleep(0.5)
     # These tests are to validate our monkey-patched number_to_human_size (see number_to_human_size_converter.rb)
     # is dividing the size by 1000 instead of using the Rails default of 1024.
-    file_size = find(:css, '#files-table>tbody>tr:first-child>td:nth-child(3)', match: :first).text
+    file_size = find(:css, '#files-table>tbody>tr:first-child>td:nth-child(2)', match: :first).text
     expect(file_size).to eq("22 KB")
-    file_size = find(:css, '#files-table>tbody>tr:nth-child(6)>td:nth-child(3)', match: :first).text
+    file_size = find(:css, '#files-table>tbody>tr:nth-child(6)>td:nth-child(2)', match: :first).text
     expect(file_size).to eq("32.7 MB")
   end
 
@@ -51,9 +53,10 @@ describe 'Show PDC Page', type: :system, js: true do
   end
   it 'correctly sorts by file size' do
     visit '/catalog/doi-10-34770-bm4s-t361'
+    sleep(0.5)
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     expect(first_filename_spot).to eq("Fig11b_readme.hdf")
-    find(:xpath, "//thead/tr/th[3]").click
+    find(:xpath, "//thead/tr/th[2]").click  # sort by file size
     first_filename_spot = find(:css, '#files-table>tbody>tr:first-child>td', match: :first).text
     # "readme.txt" is the smallest file and so now it is first
     expect(first_filename_spot).to eq("readme.txt")


### PR DESCRIPTION
Load the file list on the background via AJAX so the page with the metadata renders immediately to the user.

Co-authored-by: Claudia Lee <claudiawulee@users.noreply.github.com>
Closes #709 