### PR TITLE
experimenting with file_list size

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -272,8 +272,15 @@ class CatalogController < ApplicationController
   # therefore the return JSON must be something that DataTables can use.
   def file_list
     document = solr_find(params["id"])
-    file_list = { data: document.files }
-
+    data_list = []
+    (0..4).each do 
+      document.files.each do |file|
+        file_info = [file.full_path, file.size, file.download_url, file.display_size]
+        data_list << file_info
+      end
+    end
+    
+    file_list = { data: data_list }
     render json: file_list.to_json
   end
 

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -35,15 +35,15 @@ $(function() {
   $('#files-table').DataTable({
     ajax: "<%= catalog_file_list_path(@document) %>",
     columns: [
-        { data: 'full_path' },
-        { data: 'size' }
+        { data: 0 },
+        { data: 1 }
     ],
     columnDefs: [
       {
         // filename
         render: function (data, type, row) {
           if (type == "display") {
-            html = `<a href="${row.download_url}">${data}</a>`;
+            html = `<a href="${row[2]}">${data}</a>`;
             return html;
           }
 
@@ -62,7 +62,7 @@ $(function() {
         // file size
         render: function (data, type, row) {
           if (type == "display") {
-            return row.display_size;
+            return row[3];
           }
           return parseInt(data, 10);
         },


### PR DESCRIPTION
Seeing if file_list should be displayed as an array of hashes or an array of arrays (uses indices instead of keys to call attributes such as a file's download url)

12,000 files

5MB with hashes vs 2.4MB with arrays

[Example page used](https://datacommons.princeton.edu/discovery/catalog/doi-10-34770-rstc-eq70)