### PR TITLE
Fixes error indexing (very) large records from PDC Describe

### DIFF
--- a/app/lib/describe_indexer.rb
+++ b/app/lib/describe_indexer.rb
@@ -89,16 +89,16 @@ private
     rss_url_list.each do |url|
       process_url(url)
     rescue => ex
-      Rails.logger.warn "Error importing record from #{url}. Will retry. Exception: #{ex.message}"
+      Rails.logger.warn "Indexing: Error importing record from #{url}. Will retry. Exception: #{ex.message}"
       urls_to_retry << url
     end
 
     # retry an errored urls a second time and send error only if they don't work a second time
     urls_to_retry.each do |url|
-      Rails.logger.info "Retrying record #{url}."
+      Rails.logger.info "Indexing: Retrying record #{url}."
       process_url(url)
     rescue => ex
-      Rails.logger.error "Error importing record from #{url}. Retry failed. Exception: #{ex.message}"
+      Rails.logger.error "Indexing: Error importing record from #{url}. Retry failed. Exception: #{ex.message}"
       Honeybadger.notify "Error importing record from #{url}. Exception: #{ex.message}"
     end
   end
@@ -116,6 +116,7 @@ private
     traject_indexer.process(resource_xml)
     elapsed_index = Time.zone.now - start_index
 
-    Rails.logger.info "Successfully imported record from #{url} (read: #{'%.2f' % elapsed_read} s, index: #{'%.2f' % elapsed_index} s)"
+    timing_info = "(read: #{format('%.2f', elapsed_read)} s, index: #{format('%.2f', elapsed_index)} s)"
+    Rails.logger.info "Indexing: Successfully imported record from #{url}. #{timing_info} "
   end
 end

--- a/config/pdc_discovery.yml
+++ b/config/pdc_discovery.yml
@@ -25,5 +25,6 @@ production:
 
 staging:
   <<: *default
-  pdc_describe_rss: <%= ENV["PDC_DESCRIBE_RSS"] || "https://pdc-describe-staging.princeton.edu/describe/works.rss" %>
+  # Notice that we fetch production data for indexing since it is more realistic
+  pdc_describe_rss: <%= ENV["PDC_DESCRIBE_RSS"] || "https://pdc-describe-prod.princeton.edu/describe/works.rss" %>
   plausible_site_id: <%= "pdc-discovery-staging.princeton.edu" %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,7 +28,10 @@ set :job_template, "bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && :job'"
 #   rake "index:research_data"
 # end
 
-# Rebuild index completely every 30 minutes while we're doing active data migration
-every 30.minutes, roles: [:reindex] do
+# Rebuild index completely every 60 minutes
+#
+# Bumped the schedule to 60 minutes since it's taking close to 30 minutes now that we are
+# indexing datasets with very large number of files.
+every 60.minutes, roles: [:reindex] do
   rake "index:research_data"
 end

--- a/config/traject/pdc_describe_indexing_config.rb
+++ b/config/traject/pdc_describe_indexing_config.rb
@@ -29,7 +29,7 @@ end
 # only once per record and save it to the context so that we can re-use it.
 each_record do |record, context|
   xml = record.xpath("/hash").first.to_xml
-  context.clipboard[:record_json] = Hash.from_xml(xml).to_json
+  context.clipboard[:record_json] = Hash.from_xml(xml)["hash"].to_json
 end
 
 # ==================
@@ -115,7 +115,7 @@ end
 # Extract the author data from the pdc_describe_json and save it on its own field as JSON
 to_field 'authors_json_ss' do |_record, accumulator, context|
   pdc_json = context.clipboard[:record_json]
-  authors = JSON.parse(pdc_json).dig("hash", "resource", "creators") || []
+  authors = JSON.parse(pdc_json).dig("resource", "creators") || []
   accumulator.concat [authors.to_json]
 end
 

--- a/config/traject/pdc_describe_indexing_config.rb
+++ b/config/traject/pdc_describe_indexing_config.rb
@@ -27,6 +27,12 @@ end
 
 # the <pdc_describe_json> element contains a CDATA node with a JSON blob in it
 to_field 'pdc_describe_json_ss' do |record, accumulator, _c|
+  byebug
+  # Here is the weird part: `record.xpath("/hash/pdc_describe_json/text()").first`
+  # returns nil for the huge record.
+  #
+  # Very strange given that we confirmed that the value was set in the prep_for_indexing()
+  # method in describe_indexer.rb plus it works for all other records!
   datacite = record.xpath("/hash/pdc_describe_json/text()").first.content
   accumulator.concat [datacite]
 end

--- a/config/traject/pdc_describe_indexing_config.rb
+++ b/config/traject/pdc_describe_indexing_config.rb
@@ -12,6 +12,17 @@ settings do
   provide 'solr.url', Indexing::SolrCloudHelper.collection_writer_url
   provide 'reader_class_name', 'Traject::NokogiriReader'
   provide 'solr_writer.commit_on_close', 'true'
+
+  # ====================================================================
+  # TEMPORARY: Testing Solr parameters to see if we can get rid of errors indexing.
+  #
+  # See also: https://www.rubydoc.info/gems/traject/Traject/SolrJsonWriter
+  # Parameters to consider:
+  #   batch_size
+  #   thread_pool
+  #
+  provide 'solr_writer.batch_size', 1
+
   provide 'repository', ENV['REPOSITORY_ID']
   provide 'logger', Logger.new($stderr, level: Logger::WARN)
 end

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -3,21 +3,14 @@
 namespace :index do
   desc 'CRON JOB Re-index all research data'
   task research_data: :environment do
-    # TEMPORARY: Skip the cronjob while we are testing
-    Rails.logger.info "Indexing: Skipped cron job indexing"
-  end
-
-  task research_data_manual: :environment do
-    # TEMPORARY: Manual reindexing
     Rails.logger.info "Indexing: Research Data indexing started"
     Indexing::SolrCloudHelper.create_collection_writer
     Rails.logger.info "Indexing: Created a new collection for writing: #{Indexing::SolrCloudHelper.collection_writer_url}"
 
     Rails.logger.info "Indexing: Fetching PDC Describe records"
     Rake::Task['index:pdc_describe_research_data'].invoke
-    # TEMPORARY: Skip DataSpace for now
-    # Rails.logger.info "Indexing: Fetching DataSpace records"
-    # Rake::Task['index:dspace_research_data'].invoke
+    Rails.logger.info "Indexing: Fetching DataSpace records"
+    Rake::Task['index:dspace_research_data'].invoke
     Rails.logger.info "Indexing: Fetching completed"
 
     Indexing::SolrCloudHelper.update_solr_alias!

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -9,8 +9,8 @@ namespace :index do
 
     Rails.logger.info "Indexing: Fetching PDC Describe records"
     Rake::Task['index:pdc_describe_research_data'].invoke
-    Rails.logger.info "Indexing: Fetching DataSpace records"
-    Rake::Task['index:dspace_research_data'].invoke
+    # Rails.logger.info "Indexing: Fetching DataSpace records"
+    # Rake::Task['index:dspace_research_data'].invoke
     Rails.logger.info "Indexing: Fetching completed"
 
     Indexing::SolrCloudHelper.update_solr_alias!

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -3,12 +3,19 @@
 namespace :index do
   desc 'CRON JOB Re-index all research data'
   task research_data: :environment do
+    # TEMPORARY: Skip the cronjob while we are testing
+    Rails.logger.info "Indexing: Skipped cron job indexing"
+  end
+
+  task research_data_manual: :environment do
+    # TEMPORARY: Manual reindexing
     Rails.logger.info "Indexing: Research Data indexing started"
     Indexing::SolrCloudHelper.create_collection_writer
     Rails.logger.info "Indexing: Created a new collection for writing: #{Indexing::SolrCloudHelper.collection_writer_url}"
 
     Rails.logger.info "Indexing: Fetching PDC Describe records"
     Rake::Task['index:pdc_describe_research_data'].invoke
+    # TEMPORARY: Skip DataSpace for now
     # Rails.logger.info "Indexing: Fetching DataSpace records"
     # Rake::Task['index:dspace_research_data'].invoke
     Rails.logger.info "Indexing: Fetching completed"


### PR DESCRIPTION
Got the indexing to work even for very large records. 

This is an example record indexed in staging with 60,000 files: https://pdc-discovery-staging.princeton.edu/discovery/catalog/doi-10-34770-n42z-hb72

There is still one record that causes problems but that would be handled in a separate PR when we stop saving the file list to `files_ss` - we should be able to pick up that data from the `pdc_describe_json_ss` field instead. 

The indexing process was taking almost 1/2 hr to run so it was also colliding with the scheduled job that runs every half an hour. Therefore I updated the cron job to run once an hour instead. 

Closes #711 