### PR TITLE
Remove Source facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -123,10 +123,6 @@ class CatalogController < ApplicationController
     # and we use them when users click on the "Keywords" links in the Show page.
     config.add_facet_field 'subject_all_ssim', label: 'Keywords', show: false
 
-    # An extra facet to filter DataSpace vs PDC Describe records at will
-    # (this is handy during the migration)
-    config.add_facet_field 'data_source_ssi', label: 'Source'
-
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request
     # handler defaults, or have no facets.

--- a/spec/system/search_pdc_results_page_spec.rb
+++ b/spec/system/search_pdc_results_page_spec.rb
@@ -21,9 +21,6 @@ describe 'Search Results PDC Page', type: :system, js: true do
 
   it "renders expected fields" do
     visit '/?search_field=all_fields&q='
-    click_on "Source"
-    click_on "pdc_describe"
-    expect(page).to have_content("3D full wave fast wave modeling with realistic HHFW antenna geometry and SOL plasma in NSTX-U")
     click_on "Community"
     click_link "Princeton Plasma Physics Laboratory"
     expect(page).to have_content("Subcommunity")


### PR DESCRIPTION
We only have one source now (pdc_describe) so this facet is no longer useful.

Ref #685 