### PR TITLE
Removing dataspace references from SolrDocument

### DIFF
--- a/app/models/dataset_file.rb
+++ b/app/models/dataset_file.rb
@@ -4,7 +4,7 @@ class DatasetFile
   attr_accessor :name, :description, :format, :size, :display_size, :mime_type, :sequence, :handle, :extension,
     :source, :download_url, :full_path
 
-  def self.from_hash(data, _data_source)
+  def self.from_hash(data)
     from_hash_describe(data)
   end
 

--- a/app/views/catalog/_show_documents.html.erb
+++ b/app/views/catalog/_show_documents.html.erb
@@ -3,7 +3,7 @@
     <div class="card">
       <div class="document-downloads card-body">
 
-        <!-- Only render file download table if there are files in DataSpace -->
+        <!-- Only render file download table if there are files -->
 
         <% if @document.embargoed? %>
           <%= render_embargo_files(@document.embargo_date) %>

--- a/spec/models/dataset_file_spec.rb
+++ b/spec/models/dataset_file_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DatasetFile do
         size: 455_511,
         url: "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/qyrs-vg25/50/file_name.txt"
       }
-      file = described_class.from_hash(hash, "pdc_describe")
+      file = described_class.from_hash(hash)
       expect(file.download_url).to eq hash[:url]
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe DatasetFile do
                               filename: "10.34770/bm4s-t361/89/b.txt",
                               size: "455511",
                               download_url: "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/bm4s-t361/89/b.txt"
-                            }, "pdc_describe")
+                            })
     end
     let(:file2) do
       DatasetFile.from_hash({
@@ -52,7 +52,7 @@ RSpec.describe DatasetFile do
                               filename: "10.34770/bm4s-t361/89/a.txt",
                               size: "19271048",
                               download_url: "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/bm4s-t361/89/a.txt"
-                            }, "pdc_describe")
+                            })
     end
     let(:file3) do
       DatasetFile.from_hash({
@@ -60,7 +60,7 @@ RSpec.describe DatasetFile do
                               filename: "10.34770/bm4s-t361/89/README.txt",
                               size: "5173",
                               download_url: "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/bm4s-t361/89/README.txt"
-                            }, "pdc_describe")
+                            })
     end
 
     let(:file_array) { [file1, file2, file3] }


### PR DESCRIPTION
Including the source concept, since all our data comes from pdc_describe

refs #685