### PR TITLE
Rake task to export data from PDC Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,6 @@ You can view the [Honeybadger Uptime check](https://app.honeybadger.io/projects/
 
 To be notified of downtime enable notifications in Honeybadger under: Settings + Alerts & Integrtions + email (Edit). Enable notifications for "Uptime Events" for "PDC Discovery Production". Notice that email notifications settings are *per project*.
 
-## PPPL / OSTI data feed
-There is a data feed at `/pppl_reporting_feed.json`.
-It provides a feed of the full JSON blob from PDC Describe for every object tagged as belonging to the Princeton Plasma Physics Laboratory group, sorted by most recently updated first. This is so PPPL can harvest data sets to report to OSTI.
-This feed can be paged through using the parameters `per_page` and `page`, like this:
-
-```
-https://pdc-discovery-staging.princeton.edu/discovery/pppl_reporting_feed.json?per_page=2&page=3
-```
-
 ## Mail
 
 ### Mail on Development
@@ -130,3 +121,21 @@ Look in your default browser for the consoles
 
 ### Mail on Production
 Emails on production are sent via [Pony Express](https://github.com/pulibrary/pul-it-handbook/blob/f54dfdc7ada1ff993a721f6edb4aa1707bb3a3a5/services/smtp-mail-server.md).
+
+
+## PPPL / OSTI data feed
+There is a data feed at `/pppl_reporting_feed.json`.
+It provides a feed of the full JSON blob from PDC Describe for every object tagged as belonging to the Princeton Plasma Physics Laboratory group, sorted by most recently updated first. This is so PPPL can harvest data sets to report to OSTI.
+This feed can be paged through using the parameters `per_page` and `page`, like this:
+
+```
+https://pdc-discovery-staging.princeton.edu/discovery/pppl_reporting_feed.json?per_page=2&page=3
+```
+
+## Export of dataset information
+There are two rake tasks that produce CSV files with information about the datasets.
+
+* `bundle exec rake export:summary` generates a file that includes the list of datasets and their size (one line per dataset).
+* `bundle exec rake export:details` generates a file that includes the list of datasets and their files (one line per file).
+
+The generated file will be outputed to the `ENV["DATASET_FILE_TALLY_DIR"]` folder and will be named with todays' timestamp.

--- a/app/models/dataset_file_tally.rb
+++ b/app/models/dataset_file_tally.rb
@@ -24,11 +24,13 @@ class DatasetFileTally
 
   def filepath_summary
     directory = ENV.fetch('DATASET_FILE_TALLY_DIR', DEFAULT_FILE_PATH)
+    FileUtils.mkdir_p directory
     Pathname.new(directory).join(filename_summary).to_s
   end
 
   def filepath_details
     directory = ENV.fetch('DATASET_FILE_TALLY_DIR', DEFAULT_FILE_PATH)
+    FileUtils.mkdir_p directory
     Pathname.new(directory).join(filename_details).to_s
   end
 

--- a/app/models/dataset_file_tally.rb
+++ b/app/models/dataset_file_tally.rb
@@ -14,21 +14,28 @@ class DatasetFileTally
     @batch_size = 10
   end
 
-  # Write a file named with the current timestamp
-  def filename
-    @filename ||= "#{@timestamp.strftime('%Y_%m_%d_%H_%M')}.csv"
+  def filename_summary
+    @filename_summary ||= "#{@timestamp.strftime('%Y_%m_%d_%H_%M')}_summary.csv"
   end
 
-  # Write a file named with the current timestamp
-  def filepath
+  def filename_details
+    @filename_details ||= "#{@timestamp.strftime('%Y_%m_%d_%H_%M')}_details.csv"
+  end
+
+  def filepath_summary
     directory = ENV.fetch('DATASET_FILE_TALLY_DIR', DEFAULT_FILE_PATH)
-    Pathname.new(directory).join(filename).to_s
+    Pathname.new(directory).join(filename_summary).to_s
+  end
+
+  def filepath_details
+    directory = ENV.fetch('DATASET_FILE_TALLY_DIR', DEFAULT_FILE_PATH)
+    Pathname.new(directory).join(filename_details).to_s
   end
 
   # Exports the dataset top level information
   def summary
     init_solr_batch
-    CSV.open(filepath, "w") do |csv|
+    CSV.open(filepath_summary, "w") do |csv|
       csv << ["id", "title", "issue_date", "file_count", "total_file_size"]
       loop do
         datasets = fetch_solr_batch
@@ -44,7 +51,7 @@ class DatasetFileTally
   # Exports the dataset top level information and the file list for each dataset
   def details
     init_solr_batch
-    CSV.open(filepath, "w") do |csv|
+    CSV.open(filepath_details, "w") do |csv|
       csv << ["id", "title", "issue_date", "file_count", "total_file_size", "file_name", "file_size", "url"]
       loop do
         datasets = fetch_solr_batch

--- a/app/models/dataset_file_tally.rb
+++ b/app/models/dataset_file_tally.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# A tally of all of the files in the system at a given time. 
+# This should allow us to generate a report on current storage, 
+# as well as track growth over time. 
+class DatasetFileTally
+
+  DEFAULT_FILE_PATH = Rails.root.join("tmp", "dataset_file_tally")
+
+  attr_reader :timestamp, :filename, :filepath
+
+  # The response from the current query of solr
+  attr_reader :response
+
+  def initialize(timestamp = Time.zone.now)
+    @timestamp = timestamp
+  end
+
+  # Write a file named with the current timestamp
+  def filename
+    @filename ||= "#{@timestamp.strftime('%Y_%m_%d_%H_%M')}.csv"
+  end
+
+  # Write a file named with the current timestamp
+  def filepath
+    directory = ENV.fetch('DATASET_FILE_TALLY_DIR', DEFAULT_FILE_PATH)
+    Pathname.new(directory).join(filename).to_s
+  end
+
+  # Get all of the documents from solr so we can go through and tally them
+  def query_all_files
+    @response ||= Blacklight.default_index.connection.get 'select', params: { q: '*:*', fl: 'id,pdc_describe_json_ss' }
+  end
+
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,11 +5,13 @@ namespace :export do
   task summary: :environment do
     tally = DatasetFileTally.new
     tally.summary
+    puts "Export available at #{tally.filepath}"
   end
 
   desc "Exports the file list for each dataset"
   task details: :environment do
     tally = DatasetFileTally.new
     tally.details
+    puts "Export available at #{tally.filepath}"
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :export do
+  desc "Exports to the console the inventory of dataset and their files"
+  task datasets: :environment do
+    tally = DatasetFileTally.new
+    tally.export
+  end
+end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -5,13 +5,13 @@ namespace :export do
   task summary: :environment do
     tally = DatasetFileTally.new
     tally.summary
-    puts "Export available at #{tally.filepath}"
+    puts "Export available at #{tally.filepath_summary}"
   end
 
   desc "Exports the file list for each dataset"
   task details: :environment do
     tally = DatasetFileTally.new
     tally.details
-    puts "Export available at #{tally.filepath}"
+    puts "Export available at #{tally.filepath_details}"
   end
 end

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
 namespace :export do
-  desc "Exports to the console the inventory of dataset and their files"
-  task datasets: :environment do
+  desc "Exports a summary of the existing datasets"
+  task summary: :environment do
     tally = DatasetFileTally.new
-    tally.export
+    tally.summary
+  end
+
+  desc "Exports the file list for each dataset"
+  task details: :environment do
+    tally = DatasetFileTally.new
+    tally.details
   end
 end

--- a/spec/fixtures/files/sowing_the_seeds.json
+++ b/spec/fixtures/files/sowing_the_seeds.json
@@ -6,7 +6,7 @@
         "title_type": null
       }
     ],
-    "description": "In 2017, seven members of the Archive-It Mid-Atlantic Users Group (AITMA) conducted a study of 14 subjects representative of their stakeholder populations to assess the usability of Archive-It, a web archiving subscription service of the Internet Archive. While Archive-It is the most widely-used tool for web archiving, little is known about how users interact with the service. This study intended to teach us what users expect from web archives, which exist as another form of archival material. End-user subjects executed four search tasks using the public Archive-It interface and the Wayback Machine to access archived information on websites from the facilitators' own harvested collections and provide feedback about their experiences. The tasks were designed to have straightforward pass or fail outcomes,\r\nand the facilitators took notes on the subjects' behavior and commentary during the sessions. Overall, participants reported mildly positive impressions of Archive-It public user interface based on their session. The study identified several key areas of improvement for the Archive-It service pertaining to metadata options, terminology display, indexing of dates, and the site's search box.\r\n\r\nDownload the README.txt for a detailed description of this dataset's content.",
+    "description": "This is a fake url for testing: http://torus.example.com.\n In 2017, seven members of the Archive-It Mid-Atlantic Users Group (AITMA) conducted a study of 14 subjects representative of their stakeholder populations to assess the usability of Archive-It, a web archiving subscription service of the Internet Archive. While Archive-It is the most widely-used tool for web archiving, little is known about how users interact with the service. This study intended to teach us what users expect from web archives, which exist as another form of archival material. End-user subjects executed four search tasks using the public Archive-It interface and the Wayback Machine to access archived information on websites from the facilitators' own harvested collections and provide feedback about their experiences. The tasks were designed to have straightforward pass or fail outcomes,\r\nand the facilitators took notes on the subjects' behavior and commentary during the sessions. Overall, participants reported mildly positive impressions of Archive-It public user interface based on their session. The study identified several key areas of improvement for the Archive-It service pertaining to metadata options, terminology display, indexing of dates, and the site's search box.\r\n\r\nDownload the README.txt for a detailed description of this dataset's content.",
     "collection_tags": [],
     "creators": [
       {
@@ -76,7 +76,7 @@
     "resource_type": "Dataset",
     "resource_type_general": "Dataset",
     "publisher": "Princeton University",
-    "publication_year": "2019",
+    "publication_year": "2023",
     "ark": "ark:/88435/dsp01d791sj97j",
     "doi": "10.34770/00yp-2w12",
     "rights_many": [
@@ -87,97 +87,17 @@
       }
     ],
     "version_number": "1",
-    "related_objects": [
-      {
-        "related_identifier": "https://doi.org/10.17723/aarc-82-02-19",
-        "related_identifier_type": "DOI",
-        "relation_type": "IsReferencedBy",
-        "valid_type_values": [
-          "ARK",
-          "arXiv",
-          "bibcode",
-          "DOI",
-          "EAN13",
-          "EISSN",
-          "Handle",
-          "ISBN",
-          "ISSN",
-          "ISTC",
-          "LISSN",
-          "LSID",
-          "PMID",
-          "PURL",
-          "UPC",
-          "URL",
-          "URN",
-          "IGSN",
-          "w3id"
-        ],
-        "valid_related_identifier_type": true,
-        "valid_relationship_types": [
-          "IsCitedBy",
-          "Cites",
-          "IsSupplementTo",
-          "IsSupplementedBy",
-          "IsContinuedBy",
-          "Continues",
-          "HasMetadata",
-          "IsMetadataFor",
-          "IsNewVersionOf",
-          "IsPreviousVersionOf",
-          "HasVersion",
-          "IsVersionOf",
-          "IsPartOf",
-          "HasPart",
-          "IsReferencedBy",
-          "References",
-          "IsDocumentedBy",
-          "Documents",
-          "IsCompiledBy",
-          "Compiles",
-          "IsVariantFormOf",
-          "IsOriginalFormOf",
-          "IsIdenticalTo",
-          "IsReviewedBy",
-          "Reviews",
-          "IsDerivedFrom",
-          "IsSourceOf",
-          "IsObsoletedBy",
-          "Obsoletes",
-          "IsDescribedBy",
-          "Describes",
-          "IsRequiredBy",
-          "Requires"
-        ],
-        "valid_relation_type": true,
-        "errors": []
-      }
-    ],
+    "related_objects": [],
     "keywords": [],
     "contributors": [],
     "organizational_contributors": [],
     "funders": [],
-    "domains": [
-      "Humanities"
-    ],
+    "domains": [],
     "communities": [],
     "subcommunities": [],
     "migrated": true
   },
-  "files": [
-    {
-      "filename": "10.34770/00yp-2w12/54/Archive-It-UsabilityTestDataAnalysis-2017.xlsx",
-      "size": 94578,
-      "display_size": "94.6 KB",
-      "url": "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/00yp-2w12/54/Archive-It-UsabilityTestDataAnalysis-2017.xlsx"
-    },
-    {
-      "filename": "10.34770/00yp-2w12/54/readmearchiveitusability.rtf",
-      "size": 5125,
-      "display_size": "5.13 KB",
-      "url": "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/00yp-2w12/54/readmearchiveitusability.rtf"
-    }
-  ],
+  "files": [],
   "group": {
     "title": "Princeton Research Data Service (PRDS)",
     "description": "",
@@ -187,5 +107,5 @@
   },
   "embargo_date": null,
   "created_at": "2023-07-11T11:06:10Z",
-  "updated_at": "2024-07-30T14:21:10Z"
+  "updated_at": "2023-09-13T08:23:50Z"
 }

--- a/spec/fixtures/files/sowing_the_seeds.json
+++ b/spec/fixtures/files/sowing_the_seeds.json
@@ -6,7 +6,7 @@
         "title_type": null
       }
     ],
-    "description": "This is a fake url for testing: http://torus.example.com.\n In 2017, seven members of the Archive-It Mid-Atlantic Users Group (AITMA) conducted a study of 14 subjects representative of their stakeholder populations to assess the usability of Archive-It, a web archiving subscription service of the Internet Archive. While Archive-It is the most widely-used tool for web archiving, little is known about how users interact with the service. This study intended to teach us what users expect from web archives, which exist as another form of archival material. End-user subjects executed four search tasks using the public Archive-It interface and the Wayback Machine to access archived information on websites from the facilitators' own harvested collections and provide feedback about their experiences. The tasks were designed to have straightforward pass or fail outcomes,\r\nand the facilitators took notes on the subjects' behavior and commentary during the sessions. Overall, participants reported mildly positive impressions of Archive-It public user interface based on their session. The study identified several key areas of improvement for the Archive-It service pertaining to metadata options, terminology display, indexing of dates, and the site's search box.\r\n\r\nDownload the README.txt for a detailed description of this dataset's content.",
+    "description": "In 2017, seven members of the Archive-It Mid-Atlantic Users Group (AITMA) conducted a study of 14 subjects representative of their stakeholder populations to assess the usability of Archive-It, a web archiving subscription service of the Internet Archive. While Archive-It is the most widely-used tool for web archiving, little is known about how users interact with the service. This study intended to teach us what users expect from web archives, which exist as another form of archival material. End-user subjects executed four search tasks using the public Archive-It interface and the Wayback Machine to access archived information on websites from the facilitators' own harvested collections and provide feedback about their experiences. The tasks were designed to have straightforward pass or fail outcomes,\r\nand the facilitators took notes on the subjects' behavior and commentary during the sessions. Overall, participants reported mildly positive impressions of Archive-It public user interface based on their session. The study identified several key areas of improvement for the Archive-It service pertaining to metadata options, terminology display, indexing of dates, and the site's search box.\r\n\r\nDownload the README.txt for a detailed description of this dataset's content.",
     "collection_tags": [],
     "creators": [
       {
@@ -76,7 +76,7 @@
     "resource_type": "Dataset",
     "resource_type_general": "Dataset",
     "publisher": "Princeton University",
-    "publication_year": "2023",
+    "publication_year": "2019",
     "ark": "ark:/88435/dsp01d791sj97j",
     "doi": "10.34770/00yp-2w12",
     "rights_many": [
@@ -87,17 +87,97 @@
       }
     ],
     "version_number": "1",
-    "related_objects": [],
+    "related_objects": [
+      {
+        "related_identifier": "https://doi.org/10.17723/aarc-82-02-19",
+        "related_identifier_type": "DOI",
+        "relation_type": "IsReferencedBy",
+        "valid_type_values": [
+          "ARK",
+          "arXiv",
+          "bibcode",
+          "DOI",
+          "EAN13",
+          "EISSN",
+          "Handle",
+          "ISBN",
+          "ISSN",
+          "ISTC",
+          "LISSN",
+          "LSID",
+          "PMID",
+          "PURL",
+          "UPC",
+          "URL",
+          "URN",
+          "IGSN",
+          "w3id"
+        ],
+        "valid_related_identifier_type": true,
+        "valid_relationship_types": [
+          "IsCitedBy",
+          "Cites",
+          "IsSupplementTo",
+          "IsSupplementedBy",
+          "IsContinuedBy",
+          "Continues",
+          "HasMetadata",
+          "IsMetadataFor",
+          "IsNewVersionOf",
+          "IsPreviousVersionOf",
+          "HasVersion",
+          "IsVersionOf",
+          "IsPartOf",
+          "HasPart",
+          "IsReferencedBy",
+          "References",
+          "IsDocumentedBy",
+          "Documents",
+          "IsCompiledBy",
+          "Compiles",
+          "IsVariantFormOf",
+          "IsOriginalFormOf",
+          "IsIdenticalTo",
+          "IsReviewedBy",
+          "Reviews",
+          "IsDerivedFrom",
+          "IsSourceOf",
+          "IsObsoletedBy",
+          "Obsoletes",
+          "IsDescribedBy",
+          "Describes",
+          "IsRequiredBy",
+          "Requires"
+        ],
+        "valid_relation_type": true,
+        "errors": []
+      }
+    ],
     "keywords": [],
     "contributors": [],
     "organizational_contributors": [],
     "funders": [],
-    "domains": [],
+    "domains": [
+      "Humanities"
+    ],
     "communities": [],
     "subcommunities": [],
     "migrated": true
   },
-  "files": [],
+  "files": [
+    {
+      "filename": "10.34770/00yp-2w12/54/Archive-It-UsabilityTestDataAnalysis-2017.xlsx",
+      "size": 94578,
+      "display_size": "94.6 KB",
+      "url": "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/00yp-2w12/54/Archive-It-UsabilityTestDataAnalysis-2017.xlsx"
+    },
+    {
+      "filename": "10.34770/00yp-2w12/54/readmearchiveitusability.rtf",
+      "size": 5125,
+      "display_size": "5.13 KB",
+      "url": "https://g-ef94ef.f0ad1.36fe.data.globus.org/10.34770/00yp-2w12/54/readmearchiveitusability.rtf"
+    }
+  ],
   "group": {
     "title": "Princeton Research Data Service (PRDS)",
     "description": "",
@@ -107,5 +187,5 @@
   },
   "embargo_date": null,
   "created_at": "2023-07-11T11:06:10Z",
-  "updated_at": "2023-09-13T08:23:50Z"
+  "updated_at": "2024-07-30T14:21:10Z"
 }

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe DatasetFileTally do
   before(:all) do
     Blacklight.default_index.connection.delete_by_query("*:*")
     Blacklight.default_index.connection.commit
-    load_describe_dataset
+    load_describe_small_data
   end
 
-  let(:timestamp) { Time.parse("2025-03-25 18:01") }
   let(:dft) { described_class.new(timestamp) }
+  let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:01") }
 
   it 'has a timestamp' do
-    expect(dft.timestamp.year).to eq Time.now.year
+    expect(dft.timestamp.year).to eq Time.now.in_time_zone.year
   end
 
   it 'makes a filename based on the date and time' do
@@ -25,9 +25,31 @@ RSpec.describe DatasetFileTally do
     expect(dft.filepath).to eq Rails.root.join("tmp", "dataset_file_tally", dft.filename).to_s
   end
 
+  context "#summary" do
+    let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:02") }
 
-  # it 'queries for all of the files in solr' do
-  #   expect(dft.query_all_files["response"]["numFound"]).to eq 67
-  # end
+    it 'produces an export with the sumamry data only' do
+      dft.summary
+      lines = File.readlines(dft.filepath)
+      expect(lines.count).to be 3
+      expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size\n"
+      expect(lines[1]).to eq "doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2019,2,99703\n"
+      expect(lines[2]).to eq "doi-10-34770-r75s-9j74,bitKlavier Grand Sample Library—Binaural Mic Image,2021,4,1108910\n"
+    end
+  end
 
+  # rubocop:disable Layout/LineLength
+  context "#details" do
+    let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:03") }
+
+    it 'produces an export with the file list included' do
+      dft.details
+      lines = File.readlines(dft.filepath)
+      expect(lines.count).to be 7
+      expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size,file_name,file_size,url\n"
+      expect(lines[1].start_with?("doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2019,2,99703,Archive-It-UsabilityTestDataAnalysis-2017.xlsx,94578,https")).to be true
+      expect(lines[6].start_with?("doi-10-34770-r75s-9j74,bitKlavier Grand Sample Library—Binaural Mic Image,2021,4,1108910,folder-a/file3.txt,396003,https")).to be true
+    end
+  end
+  # rubocop:enble Layout/LineLength
 end

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'csv'
+
+RSpec.describe DatasetFileTally do
+  before(:all) do
+    Blacklight.default_index.connection.delete_by_query("*:*")
+    Blacklight.default_index.connection.commit
+    load_describe_dataset
+  end
+
+  let(:timestamp) { Time.parse("2025-03-25 18:01") }
+  let(:dft) { described_class.new(timestamp) }
+
+  it 'has a timestamp' do
+    expect(dft.timestamp.year).to eq Time.now.year
+  end
+
+  it 'makes a filename based on the date and time' do
+    expect(dft.filename).to eq "2025_03_25_18_01.csv"
+  end
+
+  it 'writes the file to a configurable directory' do
+    expect(dft.filepath).to eq Rails.root.join("tmp", "dataset_file_tally", dft.filename).to_s
+  end
+  
+
+  it 'queries for all of the files in solr' do
+    expect(dft.query_all_files["response"]["numFound"]).to eq 67
+  end
+
+end

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DatasetFileTally do
   end
 
   let(:dft) { described_class.new(timestamp) }
-  let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:01") }
+  let(:timestamp) { Time.zone.parse("2025-03-25 18:01") }
 
   it 'has a timestamp' do
     expect(dft.timestamp.year).to eq Time.now.in_time_zone.year
@@ -26,7 +26,7 @@ RSpec.describe DatasetFileTally do
   end
 
   context "#summary" do
-    let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:02") }
+    let(:timestamp) { Time.zone.parse("2025-03-25 18:02") }
 
     it 'produces an export with the sumamry data only' do
       dft.summary
@@ -40,7 +40,7 @@ RSpec.describe DatasetFileTally do
 
   # rubocop:disable Layout/LineLength
   context "#details" do
-    let(:timestamp) { Time.parse.in_time_zone("2025-03-25 18:03") }
+    let(:timestamp) { Time.zone.parse("2025-03-25 18:03") }
 
     it 'produces an export with the file list included' do
       dft.details

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe DatasetFileTally do
   it 'writes the file to a configurable directory' do
     expect(dft.filepath).to eq Rails.root.join("tmp", "dataset_file_tally", dft.filename).to_s
   end
-  
 
-  it 'queries for all of the files in solr' do
-    expect(dft.query_all_files["response"]["numFound"]).to eq 67
-  end
+
+  # it 'queries for all of the files in solr' do
+  #   expect(dft.query_all_files["response"]["numFound"]).to eq 67
+  # end
 
 end

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -19,11 +19,12 @@ RSpec.describe DatasetFileTally do
   end
 
   it 'makes a filename based on the date and time' do
-    expect(dft.filename).to eq "2025_03_25_18_01.csv"
+    expect(dft.filename_summary).to eq "2025_03_25_18_01_summary.csv"
+    expect(dft.filename_details).to eq "2025_03_25_18_01_details.csv"
   end
 
   it 'writes the file to a configurable directory' do
-    expect(dft.filepath).to eq Rails.root.join("tmp", "dataset_file_tally", dft.filename).to_s
+    expect(dft.filepath_summary).to eq Rails.root.join("tmp", "dataset_file_tally", dft.filepath_summary).to_s
   end
 
   context "#summary" do
@@ -31,7 +32,7 @@ RSpec.describe DatasetFileTally do
 
     it 'produces an export with the sumamry data only' do
       dft.summary
-      lines = File.readlines(dft.filepath)
+      lines = File.readlines(dft.filepath_summary)
       expect(lines.count).to be 3
       expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size\n"
       expect(lines[1]).to eq "doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2023,0,0\n"
@@ -44,7 +45,7 @@ RSpec.describe DatasetFileTally do
 
     it 'produces an export with the file list included' do
       dft.details
-      lines = File.readlines(dft.filepath)
+      lines = File.readlines(dft.filepath_details)
       expect(lines.count).to eq 5
       expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size,file_name,file_size,url\n"
       expect(lines.find { |line| line.start_with?(file_info_line) }).to_not be nil

--- a/spec/models/dataset_file_tally_spec.rb
+++ b/spec/models/dataset_file_tally_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe DatasetFileTally do
 
   let(:dft) { described_class.new(timestamp) }
   let(:timestamp) { Time.zone.parse("2025-03-25 18:01") }
+  let(:file_info_line) { "doi-10-34770-r75s-9j74,bitKlavier Grand Sample Library—Binaural Mic Image,2021,4,1108910,folder-a/file3.txt,396003,https" }
 
   it 'has a timestamp' do
     expect(dft.timestamp.year).to eq Time.now.in_time_zone.year
@@ -33,23 +34,20 @@ RSpec.describe DatasetFileTally do
       lines = File.readlines(dft.filepath)
       expect(lines.count).to be 3
       expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size\n"
-      expect(lines[1]).to eq "doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2019,2,99703\n"
+      expect(lines[1]).to eq "doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2023,0,0\n"
       expect(lines[2]).to eq "doi-10-34770-r75s-9j74,bitKlavier Grand Sample Library—Binaural Mic Image,2021,4,1108910\n"
     end
   end
 
-  # rubocop:disable Layout/LineLength
   context "#details" do
     let(:timestamp) { Time.zone.parse("2025-03-25 18:03") }
 
     it 'produces an export with the file list included' do
       dft.details
       lines = File.readlines(dft.filepath)
-      expect(lines.count).to be 7
+      expect(lines.count).to eq 5
       expect(lines[0]).to eq "id,title,issue_date,file_count,total_file_size,file_name,file_size,url\n"
-      expect(lines[1].start_with?("doi-10-34770-00yp-2w12,Sowing the Seeds for More Usable Web Archives: A Usability Study of Archive-It,2019,2,99703,Archive-It-UsabilityTestDataAnalysis-2017.xlsx,94578,https")).to be true
-      expect(lines[6].start_with?("doi-10-34770-r75s-9j74,bitKlavier Grand Sample Library—Binaural Mic Image,2021,4,1108910,folder-a/file3.txt,396003,https")).to be true
+      expect(lines.find { |line| line.start_with?(file_info_line) }).to_not be nil
     end
   end
-  # rubocop:enble Layout/LineLength
 end


### PR DESCRIPTION
Implements the export of the data in PDC Discovery. There are two ways in which the data can be exported: summary and details.  

* Summary just lists the datasets and how many files and how much space they take (one line per dataset)
* Details list the summary plus each file for the dataset (one line per file)

There are two rake tasks that can be run to generate these reports: `bundle exec rake export:summary` and `bundle exec rake export:details`. 

This PR does not schedule them to run on schedule. If we need that we can add another PR.

Closes #781 