### PR TITLE
Removed encoding so that RUN_IN_BROWSER rspec testing will work

### DIFF
--- a/spec/system/bitklavier_single_item_metadata_spec.rb
+++ b/spec/system/bitklavier_single_item_metadata_spec.rb
@@ -35,7 +35,7 @@ describe 'PDC Describe Bitklavier Single item page', type: :system, js: true do
     author_top_of_page = '<span class="author-name">'
     author_popover_title = 'data-original-title="Trueman, Daniel"'
     author_popover_orcid = 'https://orcid.org/1234-1234-1234-1234'
-    author_popover_affiliation = "&lt;a href='/?f[authors_affiliation_ssim][]=Princeton+Plasma+Physics+Laboratory&amp;q=&amp;search_field=all_fields'&gt;Princeton Plasma Physics Laboratory&lt;/a&gt;"
+    author_popover_affiliation = "/?f[authors_affiliation_ssim][]=Princeton+Plasma+Physics+Laboratory"
     author_popover_search_orcid = '/?&amp;q=1234-1234-1234-1234&amp;search_field=orcid'
     author_meta = 'Trueman, Daniel (Princeton Plasma Physics Laboratory)'
     expect(page.html.include?(author_top_of_page)).to be true


### PR DESCRIPTION
Related to https://github.com/pulibrary/pdc_discovery/issues/812

When `RUN_IN_BROWSER=true` is set while running rspec, the test suite fails on this test due to a difference in encoding between web driver used to run the tests in the terminal vs. the browser used to run the test visibly.

This should make it so that the tests pass accurately in both cases.