### PR TITLE
Add google tag manager.

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -22,6 +22,9 @@
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
+    <% if Rails.env.production? %>
+      <%= render partial: 'shared/analytics' %>
+    <% end %>
     <%= render 'shared/plausible' %>
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.11.3/css/jquery.dataTables.min.css"/>
@@ -36,6 +39,9 @@
     <%= render partial: 'shared/schema_org'%>
   </head>
   <body class="<%= render_body_class %>">
+    <% if Rails.env.production? %>
+      <%= render partial: 'shared/analytics_noscript' %>
+    <% end %>
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,0 +1,3 @@
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5WDW3R6V');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/shared/_analytics_noscript.html.erb
+++ b/app/views/shared/_analytics_noscript.html.erb
@@ -1,0 +1,3 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5WDW3R6V"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
Google tag manager is a tool that will allow AUX to customize how
analytics is handled across all of our properties without being forced
to customize every application, or ask that we do it for them.

This doesn't mean we're adding google analytics to PDC Discover. In
fact, this will allow us to easily test a couple different fully local
and private analytics options (like at
https://analytics.lib.princeton.edu).

The google tag manager privacy policy is much more strict than Google
Analytics': https://support.google.com/tagmanager/answer/9323295?hl=en

Work towards pulibrary/dpul-collections#709
