### PR TITLE
Update hostnames of staging servers

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-server "pdc-discovery-staging1.princeton.edu", user: "deploy", roles: %w[app db web reindex]
-server "pdc-discovery-staging2.princeton.edu", user: "deploy", roles: %w[app db web]
+server "pdc-discovery-staging1.lib.princeton.edu", user: "deploy", roles: %w[app db web reindex]
+server "pdc-discovery-staging2.lib.princeton.edu", user: "deploy", roles: %w[app db web]


### PR DESCRIPTION
As we're rebuilding pdc-discovery-staging we are also moving it to the .lib (internal) domain.

Ref #870 